### PR TITLE
Artemis

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
@@ -20,7 +20,7 @@ public class LigaSyncMatchDTOMapper implements DataTransferObjectMapper {
         // empty private constructor
     }
 
-    private static LigaSyncMatchDTO apply(MatchDO matchDO) {
+    public static LigaSyncMatchDTO apply(MatchDO matchDO) {
 
         final Long id = matchDO.getId();
         final Long version = matchDO.getVersion();
@@ -34,11 +34,26 @@ public class LigaSyncMatchDTOMapper implements DataTransferObjectMapper {
         final Long matchIdGegner = null;
         final Long naechsteMatchId = null;
         final Long naechsteNaechsteMatchNrMatchId = null;
-        final Integer strafpunkteSatz1 = Math.toIntExact(matchDO.getStrafPunkteSatz1());
-        final Integer strafpunkteSatz2 = Math.toIntExact(matchDO.getStrafPunkteSatz2());
-        final Integer strafpunkteSatz3 = Math.toIntExact(matchDO.getStrafPunkteSatz3());
-        final Integer strafpunkteSatz4 = Math.toIntExact(matchDO.getStrafPunkteSatz4());
-        final Integer strafpunkteSatz5 = Math.toIntExact(matchDO.getStrafPunkteSatz5());
+        int strafpunkteSatz1=0;
+        if(matchDO.getStrafPunkteSatz1()!=null){
+            strafpunkteSatz1 = Math.toIntExact(matchDO.getStrafPunkteSatz1());
+        }
+        int strafpunkteSatz2=0;
+        if(matchDO.getStrafPunkteSatz2()!=null){
+            strafpunkteSatz2 = Math.toIntExact(matchDO.getStrafPunkteSatz2());
+        }
+        int strafpunkteSatz3=0;
+        if(matchDO.getStrafPunkteSatz3()!=null){
+            strafpunkteSatz3 = Math.toIntExact(matchDO.getStrafPunkteSatz3());
+        }
+        int strafpunkteSatz4=0;
+        if(matchDO.getStrafPunkteSatz4()!=null){
+            strafpunkteSatz4 = Math.toIntExact(matchDO.getStrafPunkteSatz4());
+        }
+        int strafpunkteSatz5=0;
+        if(matchDO.getStrafPunkteSatz5()!=null){
+            strafpunkteSatz5 = Math.toIntExact(matchDO.getStrafPunkteSatz5());
+        }
 
         return new LigaSyncMatchDTO(id, version, wettkampfId, matchNr, matchScheibennummer, mannschaftsId,
                 mannschaftName, nameGegner, scheibennummerGegner, matchIdGegner, naechsteMatchId,

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/LigaSyncMatchDTO.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/LigaSyncMatchDTO.java
@@ -1,6 +1,8 @@
 package de.bogenliga.application.services.v1.sync.model;
 
-public class LigaSyncMatchDTO {
+import de.bogenliga.application.common.service.types.DataTransferObject;
+
+public class LigaSyncMatchDTO implements DataTransferObject {
     private Long id; //match-Id
     private Long version;
     private Long wettkampfId;
@@ -59,5 +61,30 @@ public class LigaSyncMatchDTO {
         this.strafpunkteSatz3 = strafpunkteSatz3;
         this.strafpunkteSatz4 = strafpunkteSatz4;
         this.strafpunkteSatz5 = strafpunkteSatz5;
+    }
+
+    public void setMannschaftName(String mannschaftName) {
+        this.mannschaftName = mannschaftName;
+    }
+
+    public void setNameGegner(String nameGegner){
+        this.nameGegner = nameGegner;
+    }
+
+    public void setScheibennummerGegner(Integer scheibennummerGegner){
+        this.scheibennummerGegner = scheibennummerGegner;
+    }
+
+    public void setMatchIdGegner(Long matchIdGegner){
+        this.matchIdGegner = matchIdGegner;
+    }
+
+    public void setNaechsteMatchId(Long naechsteMatchId){
+        this.naechsteMatchId = naechsteMatchId;
+
+    }
+
+    public void setNaechsteNaechsteMatchNrMatchId(Long naechsteNaechsteMatchNrMatchId){
+        this.naechsteNaechsteMatchNrMatchId = naechsteNaechsteMatchNrMatchId;
     }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -7,7 +7,6 @@ import de.bogenliga.application.business.match.api.MatchComponent;
 import de.bogenliga.application.business.ligatabelle.api.types.LigatabelleDO;
 
 import de.bogenliga.application.business.match.api.types.MatchDO;
-import de.bogenliga.application.business.match.impl.business.MatchComponentImpl;
 import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.services.v1.sync.mapper.LigaSyncLigatabelleDTOMapper;
@@ -56,7 +55,6 @@ public class SyncService implements ServiceFacade {
      */
     @Autowired
     public SyncService(final LigatabelleComponent ligatabelleComponent,
-                        final MatchComponentImpl matchComponentImpl,
                        final MatchComponent matchComponent) {
         this.ligatabelleComponent = ligatabelleComponent;
         this.matchComponent = matchComponent;
@@ -107,13 +105,17 @@ public class SyncService implements ServiceFacade {
 
         List<LigamatchBE> wettkampfMatches = matchComponent.getLigamatchesByWettkampfId(wettkampfid);
 
-        final List<MatchDO> matchDOs = new ArrayList<>();
+        List<LigaSyncMatchDTO> ligaSyncMatchDTOList = new ArrayList<>();
 
-        for( LigamatchBE einmatch: wettkampfMatches) {
-            MatchDO matchDO = LigamatchToMatchMapper.LigamatchToMatchDO.apply(einmatch);
-            matchDOs.add(matchDO);
+        for( LigamatchBE currentLigamatchBE: wettkampfMatches) {
+            MatchDO matchDO = LigamatchToMatchMapper.LigamatchToMatchDO.apply(currentLigamatchBE);
+            LigaSyncMatchDTO ligaSyncMatchDTO = LigaSyncMatchDTOMapper.apply(matchDO);
+            ligaSyncMatchDTO.setMannschaftName(currentLigamatchBE.getMannschaftName());
+            ligaSyncMatchDTO.setNaechsteMatchId(currentLigamatchBE.getNaechsteMatchId());
+            ligaSyncMatchDTO.setNaechsteNaechsteMatchNrMatchId(currentLigamatchBE.getNaechsteNaechsteMatchId());
+            ligaSyncMatchDTOList.add(ligaSyncMatchDTO);
         }
-        return matchDOs.stream().map(LigaSyncMatchDTOMapper.toDTO).collect(Collectors.toList());
+        return ligaSyncMatchDTOList;
     }
 
     private void checkMatchId(Long matchId) {


### PR DESCRIPTION
BSAPP-1095: Die Funktion zum Lesen der Ligamatches wurde implementiert, es wurde ein LigaSyncMatchDTOMapper hinzugefügt
Fehlerbehandlung von ArithmeticException Prüfung auf null vor Konversion der Satzpunkte.
LigaSyncMatchDTO Setter für einige Attribute hinzugefügt.
Beim LigaSyncMatchDTO-Objekte werden nun die Attribute MannschaftsName, naechsteMatchId, neachsteNaechsteMatchId zugewiesen.
Nicht benutze Variable und Import entfernt.