### PR TITLE
Bsapp 1095

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/match/service/MatchService.java
@@ -241,6 +241,7 @@ public class MatchService implements ServiceFacade {
         this.log(matchDTO1, SERVICE_FIND_MATCHES_BY_IDS);
         this.log(matchDTO2, SERVICE_FIND_MATCHES_BY_IDS);
 
+
         return matches;
     }
 
@@ -357,6 +358,8 @@ public class MatchService implements ServiceFacade {
     private void saveMatch(MatchDTO matchDTO, Long userId) {
 
         MatchDO matchDO = MatchDTOMapper.toDO.apply(matchDTO);
+
+
         matchComponent.update(matchDO, userId);
         List<MannschaftsmitgliedDO> mannschaftsmitgliedDOS =
                 mannschaftsmitgliedComponent.findAllSchuetzeInTeam(matchDTO.getMannschaftId());
@@ -369,9 +372,11 @@ public class MatchService implements ServiceFacade {
         Preconditions.checkArgument(mannschaftsmitgliedDOS.size() >= 3,
                 String.format(ERR_SIZE_TEMPLATE, SERVICE_SAVE_MATCHES, "mannschaftsmitgliedDOS", 3));
 
+
         for (PasseDTO passeDTO : matchDTO.getPassen()) {
             createOrUpdatePasse(passeDTO, userId, mannschaftsmitgliedDOS);
         }
+
     }
 
 
@@ -386,11 +391,16 @@ public class MatchService implements ServiceFacade {
                                      List<MannschaftsmitgliedDO> mannschaftsmitgliedDOS){
 
         checkPreconditions(passeDTO, passeConditionErrors);
+
+
         passeDTO.setDsbMitgliedId(getMemberIdFor(passeDTO, mannschaftsmitgliedDOS));
+
         Preconditions.checkArgument(passeDTO.getDsbMitgliedId() != null,
                 String.format(ERR_NOT_NULL_TEMPLATE, "createOrUpdatePasse", "dsbMitgliedId"));
 
         PasseDO passeDO = PasseDTOMapper.toDO.apply(passeDTO);
+
+
         if (passeExists(passeDO)) {
             passeComponent.update(passeDO, userId);
         } else {
@@ -785,14 +795,19 @@ public class MatchService implements ServiceFacade {
 
 
             List<LigapasseBE> ligapasseBEList = passeComponent.getLigapassenByLigamatchId(matchId);
+
+
             List<PasseDO> passeDOs = ligapasseBEList.stream().map(LigapasseToPasseMapper.ligapasseToPasseDO).collect(Collectors.toList());
             List<PasseDTO> passeDTOs = passeDOs.stream().map(PasseDTOMapper.toDTO).collect(Collectors.toList());
+
 
             for (int i = 0; i < passeDTOs.size(); i++){
                 passeDTOs.get(i).setRueckennummer(ligapasseBEList.get(i).getMannschaftsmitgliedRueckennummer());
                 Preconditions.checkArgument(passeDTOs.get(i).getDsbMitgliedId() != null,
                         String.format(ERR_NOT_NULL_TEMPLATE, "getMatchFromId", "dsbMitgliedId"));
             }
+
+
 
             matchDTO.setPassen(passeDTOs);
             return matchDTO;

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -131,20 +131,26 @@ public class SyncService implements ServiceFacade {
             ligaSyncMatchDTO.setMannschaftName(currentLigamatchBE.getMannschaftName());
             ligaSyncMatchDTO.setNaechsteMatchId(currentLigamatchBE.getNaechsteMatchId());
             ligaSyncMatchDTO.setNaechsteNaechsteMatchNrMatchId(currentLigamatchBE.getNaechsteNaechsteMatchId());
-            LigamatchBE gegnerLigaMatchBE = wettkampfMatches.stream().
-                    filter(t -> t.getMatchNr() == matchDO.getNr() &&
-                            t.getBegegnung() == matchDO.getBegegnung() &&
-                            t.getScheibennummer() != matchDO.getScheibenNummer()).
-                    findFirst().orElse(null);
-            if(gegnerLigaMatchBE != null &&
-                    ligaSyncMatchDTO.getMannschaftName() != null &&
-                    !ligaSyncMatchDTO.getMannschaftName().equals(gegnerLigaMatchBE.getMannschaftName()) &&
-                    ligaSyncMatchDTO.getId() != gegnerLigaMatchBE.getMatchId() &&
-                    gegnerLigaMatchBE.getScheibennummer() != null &&
-                    ligaSyncMatchDTO.getMatchScheibennummer() != Math.toIntExact(gegnerLigaMatchBE.getScheibennummer())){
-                ligaSyncMatchDTO.setNameGegner(gegnerLigaMatchBE.getMannschaftName());
-                ligaSyncMatchDTO.setMatchIdGegner(gegnerLigaMatchBE.getMatchId());
-                ligaSyncMatchDTO.setScheibennummerGegner(Math.toIntExact(gegnerLigaMatchBE.getScheibennummer()));
+
+            List<LigamatchBE> ligaGegnerMatchBEList = wettkampfMatches.stream().
+                    filter(t -> (t.getMatchNr() != null ? t.getMatchNr().equals(matchDO.getNr()) : false) &&
+                            (t.getBegegnung() != null ? t.getBegegnung().equals(matchDO.getBegegnung()) : false) &&
+                            (t.getScheibennummer() != null ? !t.getScheibennummer().equals(matchDO.getScheibenNummer()) : false))
+                    .collect(Collectors.toList());
+
+            LigamatchBE gegnerLigaMatchBE = null;
+
+            if(ligaGegnerMatchBEList != null && ligaGegnerMatchBEList.size() == 1 && ligaGegnerMatchBEList.get(0) != null){
+                gegnerLigaMatchBE = ligaGegnerMatchBEList.get(0);
+                if(ligaSyncMatchDTO.getMannschaftName() != null &&
+                        !ligaSyncMatchDTO.getMannschaftName().equals(gegnerLigaMatchBE.getMannschaftName()) &&
+                        (ligaSyncMatchDTO.getId() != null ? !ligaSyncMatchDTO.getId().equals(gegnerLigaMatchBE.getMatchId()) : false) &&
+                        gegnerLigaMatchBE.getScheibennummer() != null &&
+                        ligaSyncMatchDTO.getMatchScheibennummer() != Math.toIntExact(gegnerLigaMatchBE.getScheibennummer())){
+                    ligaSyncMatchDTO.setNameGegner(gegnerLigaMatchBE.getMannschaftName());
+                    ligaSyncMatchDTO.setMatchIdGegner(gegnerLigaMatchBE.getMatchId());
+                    ligaSyncMatchDTO.setScheibennummerGegner(Math.toIntExact(gegnerLigaMatchBE.getScheibennummer()));
+                }
             }
             ligaSyncMatchDTOList.add(ligaSyncMatchDTO);
         }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -1,5 +1,6 @@
 package de.bogenliga.application.services.v1.sync.service;
 
+import de.bogenliga.application.business.liga.impl.mapper.LigaMapper;
 import de.bogenliga.application.business.ligamatch.impl.entity.LigamatchBE;
 import de.bogenliga.application.business.ligamatch.impl.mapper.LigamatchToMatchMapper;
 import de.bogenliga.application.business.ligapasse.impl.entity.LigapasseBE;
@@ -132,29 +133,37 @@ public class SyncService implements ServiceFacade {
             ligaSyncMatchDTO.setNaechsteMatchId(currentLigamatchBE.getNaechsteMatchId());
             ligaSyncMatchDTO.setNaechsteNaechsteMatchNrMatchId(currentLigamatchBE.getNaechsteNaechsteMatchId());
 
-            List<LigamatchBE> ligaGegnerMatchBEList = wettkampfMatches.stream().
-                    filter(t -> (t.getMatchNr() != null ? t.getMatchNr().equals(matchDO.getNr()) : false) &&
-                            (t.getBegegnung() != null ? t.getBegegnung().equals(matchDO.getBegegnung()) : false) &&
-                            (t.getScheibennummer() != null ? !t.getScheibennummer().equals(matchDO.getScheibenNummer()) : false))
-                    .collect(Collectors.toList());
+            LigamatchBE gegnerLigaMatchBE = getGegnerLigaMatchBE(matchDO,  wettkampfMatches);
 
-            LigamatchBE gegnerLigaMatchBE = null;
-
-            if(ligaGegnerMatchBEList != null && ligaGegnerMatchBEList.size() == 1 && ligaGegnerMatchBEList.get(0) != null){
-                gegnerLigaMatchBE = ligaGegnerMatchBEList.get(0);
-                if(ligaSyncMatchDTO.getMannschaftName() != null &&
-                        !ligaSyncMatchDTO.getMannschaftName().equals(gegnerLigaMatchBE.getMannschaftName()) &&
-                        (ligaSyncMatchDTO.getId() != null ? !ligaSyncMatchDTO.getId().equals(gegnerLigaMatchBE.getMatchId()) : false) &&
-                        gegnerLigaMatchBE.getScheibennummer() != null &&
-                        ligaSyncMatchDTO.getMatchScheibennummer() != Math.toIntExact(gegnerLigaMatchBE.getScheibennummer())){
-                    ligaSyncMatchDTO.setNameGegner(gegnerLigaMatchBE.getMannschaftName());
-                    ligaSyncMatchDTO.setMatchIdGegner(gegnerLigaMatchBE.getMatchId());
-                    ligaSyncMatchDTO.setScheibennummerGegner(Math.toIntExact(gegnerLigaMatchBE.getScheibennummer()));
-                }
+            if(gegnerLigaMatchBE != null &&
+                    ligaSyncMatchDTO.getMannschaftName() != null &&
+                    !ligaSyncMatchDTO.getMannschaftName().equals(gegnerLigaMatchBE.getMannschaftName()) &&
+                    (ligaSyncMatchDTO.getId() != null && !ligaSyncMatchDTO.getId().equals(gegnerLigaMatchBE.getMatchId())) &&
+                    gegnerLigaMatchBE.getScheibennummer() != null &&
+                    ligaSyncMatchDTO.getMatchScheibennummer() != Math.toIntExact(gegnerLigaMatchBE.getScheibennummer())){
+                ligaSyncMatchDTO.setNameGegner(gegnerLigaMatchBE.getMannschaftName());
+                ligaSyncMatchDTO.setMatchIdGegner(gegnerLigaMatchBE.getMatchId());
+                ligaSyncMatchDTO.setScheibennummerGegner(Math.toIntExact(gegnerLigaMatchBE.getScheibennummer()));
             }
             ligaSyncMatchDTOList.add(ligaSyncMatchDTO);
         }
         return ligaSyncMatchDTOList;
+    }
+
+    private LigamatchBE getGegnerLigaMatchBE(MatchDO matchDO, List<LigamatchBE> wettkampfMatches) {
+        List<LigamatchBE> ligaGegnerMatchBEList = wettkampfMatches.stream().
+                filter(t -> t.getMatchNr() != null && t.getMatchNr().equals(matchDO.getNr()) &&
+                        t.getBegegnung() != null && t.getBegegnung().equals(matchDO.getBegegnung()) &&
+                        t.getScheibennummer() != null && !t.getScheibennummer().equals(matchDO.getScheibenNummer()))
+                .collect(Collectors.toList());
+
+        LigamatchBE gegnerLigaMatchBE = null;
+
+        if (ligaGegnerMatchBEList != null && ligaGegnerMatchBEList.size() == 1 && ligaGegnerMatchBEList.get(
+                0) != null) {
+            gegnerLigaMatchBE = ligaGegnerMatchBEList.get(0);
+        }
+        return gegnerLigaMatchBE;
     }
 
     private void checkMatchId(Long matchId) {

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -131,6 +131,21 @@ public class SyncService implements ServiceFacade {
             ligaSyncMatchDTO.setMannschaftName(currentLigamatchBE.getMannschaftName());
             ligaSyncMatchDTO.setNaechsteMatchId(currentLigamatchBE.getNaechsteMatchId());
             ligaSyncMatchDTO.setNaechsteNaechsteMatchNrMatchId(currentLigamatchBE.getNaechsteNaechsteMatchId());
+            LigamatchBE gegnerLigaMatchBE = wettkampfMatches.stream().
+                    filter(t -> t.getMatchNr() == matchDO.getNr() &&
+                            t.getBegegnung() == matchDO.getBegegnung() &&
+                            t.getScheibennummer() != matchDO.getScheibenNummer()).
+                    findFirst().orElse(null);
+            if(gegnerLigaMatchBE != null &&
+                    ligaSyncMatchDTO.getMannschaftName() != null &&
+                    !ligaSyncMatchDTO.getMannschaftName().equals(gegnerLigaMatchBE.getMannschaftName()) &&
+                    ligaSyncMatchDTO.getId() != gegnerLigaMatchBE.getMatchId() &&
+                    gegnerLigaMatchBE.getScheibennummer() != null &&
+                    ligaSyncMatchDTO.getMatchScheibennummer() != Math.toIntExact(gegnerLigaMatchBE.getScheibennummer())){
+                ligaSyncMatchDTO.setNameGegner(gegnerLigaMatchBE.getMannschaftName());
+                ligaSyncMatchDTO.setMatchIdGegner(gegnerLigaMatchBE.getMatchId());
+                ligaSyncMatchDTO.setScheibennummerGegner(Math.toIntExact(gegnerLigaMatchBE.getScheibennummer()));
+            }
             ligaSyncMatchDTOList.add(ligaSyncMatchDTO);
         }
         return ligaSyncMatchDTOList;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/ligapasse/impl/dao/LigapasseDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/ligapasse/impl/dao/LigapasseDAO.java
@@ -120,7 +120,7 @@ public class LigapasseDAO implements DataAccessObject {
             .selectAll()
             .from(TABLE)
             .whereEquals(MATCH_TABLE_MATCH_ID)
-            .orderBy(MATCH_TABLE_PASSE_LFDNR)
+            .orderBy(MATCH_TABLE_PASSE_ID)
             .compose().toString();
 
 
@@ -129,9 +129,5 @@ public class LigapasseDAO implements DataAccessObject {
             .from(TABLE)
             .whereEquals(MATCH_TABLE_PASSE_ID)
             .compose().toString();
-
-
-
-
 
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
@@ -325,6 +325,7 @@ public class PasseDAO implements DataAccessObject {
      */
     public PasseBE create(final PasseBE passeBE, final Long currentKampfrichterUserId) {
         basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
+        basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
 
         return basicDao.insertEntity(PASSE, passeBE);
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
@@ -325,7 +325,6 @@ public class PasseDAO implements DataAccessObject {
      */
     public PasseBE create(final PasseBE passeBE, final Long currentKampfrichterUserId) {
         basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
-        basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
 
         return basicDao.insertEntity(PASSE, passeBE);
     }


### PR DESCRIPTION
BSAPP-1095: Die Attribute "NameGegner", „scheibeNummerGegner“ und „matchIdGegner“ werden nun zugewiesen. Doppelte Zeile in PasseDAO entfernt