### PR TITLE
BSAPP-1095: Die Attribute "NameGegner", „scheibeNummerGegner“ und „ma…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/passe/impl/dao/PasseDAO.java
@@ -325,7 +325,6 @@ public class PasseDAO implements DataAccessObject {
      */
     public PasseBE create(final PasseBE passeBE, final Long currentKampfrichterUserId) {
         basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
-        basicDao.setCreationAttributes(passeBE, currentKampfrichterUserId);
 
         return basicDao.insertEntity(PASSE, passeBE);
     }


### PR DESCRIPTION
…tchIdGegner“ werden nun zugewiesen. Kommentare hinzugefügt. Doppelte Zeile in PasseDAO entfernt.