### PR TITLE
Artemis

### DIFF
--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.9.RELEASE/version>
+        <version>2.0.9.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.bogenliga</groupId>
     <artifactId>bogenliga-application</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.9</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>2.3.12.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -7,13 +7,13 @@
 
     <groupId>de.bogenliga</groupId>
     <artifactId>bogenliga-application</artifactId>
-    <version>2.0.9.RELEASE</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.6</version>
+        <version>2.0.9.RELEASE/version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.18.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.bogenliga</groupId>
     <artifactId>bogenliga-application</artifactId>
-    <version>2.0.9</version>
+    <version>2.0.9.RELEASE</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.12.RELEASE</version>
+        <version>2.0.9.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.4.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.4.RELEASE</version>
+        <version>2.7.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/pom.xml
+++ b/bogenliga/bogenliga-application/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.9.RELEASE</version>
+        <version>2.1.18.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMannschaftsmitgliedDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMannschaftsmitgliedDTOMapper.java
@@ -31,7 +31,6 @@ public class LigaSyncMannschaftsmitgliedDTOMapper implements DataTransferObjectM
 
     private static MannschaftsMitgliedDTO apply(LigaSyncMannschaftsmitgliedDTO ligaSyncMannschaftsmitgliedDTO){
         final Long id = ligaSyncMannschaftsmitgliedDTO.getId();
-        final Long version = ligaSyncMannschaftsmitgliedDTO.getVersion();
         final Long mannschaftId = ligaSyncMannschaftsmitgliedDTO.getMannschaftId();
         final Long dsbMitgliedId = ligaSyncMannschaftsmitgliedDTO.getDsbMitgliedId();
         final Long rueckennummer = ligaSyncMannschaftsmitgliedDTO.getRueckennummer();

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
@@ -98,11 +98,7 @@ public class LigaSyncMatchDTOMapper implements DataTransferObjectMapper {
         final Long wettkampfId = ligaSyncMatchDTO.getWettkampfId();
         final Long mannschaftId = ligaSyncMatchDTO.getMannschaftId();
 
-        // actually verein name...
-        final String mannschaftName = ligaSyncMatchDTO.getMannschaftName();
         final Long begegnung = null;
-        final String wettkampfTyp = null;
-        final Long wettkampfTag = null;
         final Long scheibenNummer = ligaSyncMatchDTO.getMatchScheibennummer().longValue();
         final Long matchpunkte = null;
         final Long satzpunkte = null;

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/LigaSyncMannschaftsmitgliedDTO.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/LigaSyncMannschaftsmitgliedDTO.java
@@ -9,7 +9,9 @@ package de.bogenliga.application.services.v1.sync.model;
 // ob zwichenzeitlich ein neues Mannschaftsmitgliled angelegt wurde - und die
 // Zuordnung der Datensätze (Passe) ist über die Rückennummer vorzunehmen.
 
-public class LigaSyncMannschaftsmitgliedDTO {
+import de.bogenliga.application.common.service.types.DataTransferObject;
+
+public class LigaSyncMannschaftsmitgliedDTO implements DataTransferObject {
     private Long id; //ID aus mannscjaftsmitglied_id
     private Long version;
     private Long mannschaftId;
@@ -27,6 +29,31 @@ public class LigaSyncMannschaftsmitgliedDTO {
         this.version = version;
         this.mannschaftId = mannschaftId;
         this.dsbMitgliedId = dsbMitgliedId;
+        this.rueckennummer = rueckennummer;
+    }
+
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+
+
+    public void setMannschaftId(Long mannschaftId) {
+        this.mannschaftId = mannschaftId;
+    }
+
+
+    public void setDsbMitgliedId(Long dsbMitgliedId) {
+        this.dsbMitgliedId = dsbMitgliedId;
+    }
+
+
+    public void setRueckennummer(Long rueckennummer) {
         this.rueckennummer = rueckennummer;
     }
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/SyncWrapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/model/SyncWrapper.java
@@ -78,4 +78,15 @@ public class SyncWrapper implements DataTransferObject {
     public void setWettkampfId(long wettkampfId) {
         this.wettkampfId = wettkampfId;
     }
+
+    @Override
+    public String toString() {
+        return "SyncWrapper{" +
+                "match=" + match +
+                ", passe=" + passe +
+                ", mannschaftsMitglieder=" + mannschaftsMitglieder +
+                ", offlineToken='" + offlineToken + '\'' +
+                ", wettkampfId=" + wettkampfId +
+                '}';
+    }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.naming.NoPermissionException;
-import javax.print.attribute.standard.Media;
 
 /**
  * I'm a REST resource and handle liga CRUD requests over the HTTP protocol
@@ -135,7 +134,6 @@ public class SyncService implements ServiceFacade {
      *
      * @return list of {@link LigaSyncMatchDTO} as JSON
      */
-
     @GetMapping(
             value = "match/{id}",
             produces = MediaType.APPLICATION_JSON_VALUE)
@@ -211,6 +209,7 @@ public class SyncService implements ServiceFacade {
         return mannschaftsmitgliedDOList.stream().map(LigaSyncMannschaftsmitgliedDTOMapper.toDTO).collect(
                 Collectors.toList());
     }
+
 
     /**
      * I will update the dataset of a single Wettkampf and set the OfflineToken
@@ -291,7 +290,7 @@ public class SyncService implements ServiceFacade {
                        Collectors.toList()));
     }
 
-    /* TODO
+    /**
      * I will recieve both lists: matches and passen to store data consistently in a single transaction
      * when data successfully stored, the offlinetoken in wettkampf table is to be removed
      * @return ok or list of errors
@@ -364,6 +363,7 @@ public class SyncService implements ServiceFacade {
 
         return matchDTOs;
     }
+
 
     /**
     * I delete the offline token of a wettkampf unconditionally

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -305,8 +305,6 @@ public class SyncService implements ServiceFacade {
                                                       List<LigaSyncPasseDTO> ligaSyncPasseDTOs,
                                                       Principal principal) throws NoPermissionException {
 
-        final Long userId = UserProvider.getCurrentUserId(principal);
-
         List<MatchDTO> matchDTOs = new ArrayList<>();
 
         for (LigaSyncMatchDTO ligasyncmatchDTO : ligaSyncMatchDTOs) {

--- a/bogenliga/bogenliga-application/src/main/resources/application-DEV.properties
+++ b/bogenliga/bogenliga-application/src/main/resources/application-DEV.properties
@@ -4,6 +4,7 @@ database.port=5432
 database.databaseName=swt2
 database.user=swt2
 database.password=swt2
+spring.main.allow-circular-references=true
 # JSON Web Token - Security properties
 ## UNSECURE!!!
 security.jwt.secret=secret-key

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/mapper/LigaSyncMatchDTOMapperTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/mapper/LigaSyncMatchDTOMapperTest.java
@@ -1,0 +1,61 @@
+package de.bogenliga.application.services.v1.Sync.mapper;
+
+import org.junit.Test;
+import de.bogenliga.application.business.match.api.types.LigamatchDO;
+import de.bogenliga.application.business.match.api.types.MatchDO;
+import de.bogenliga.application.services.v1.sync.mapper.LigaSyncMatchDTOMapper;
+import de.bogenliga.application.services.v1.sync.model.LigaSyncMatchDTO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Adrian Kempf
+ */
+public class LigaSyncMatchDTOMapperTest {
+    protected static final Long MATCH_ID = 1L;
+    private static final long version = 1234;
+    private static final Long MATCH_WETTKAMPF_ID = 2L;
+    protected static final Long MATCH_NR = 1L;
+    protected static final Long MATCH_BEGEGNUNG = 1L;
+    protected static final Long MATCH_SCHEIBENNUMMER = 3L;
+    protected static final Long MATCH_MATCHPUNKTE = 6L;
+    protected static final Long MATCH_SATZPUNKTE = 3L;
+    protected static final Long MATCH_MANNSCHAFT_ID = 1L;
+    protected static final String MATCH_MANNSCHAFT_NAME = "TSV_Grafenberg";
+    protected static final String MATCH_NAME_GEGNER = "TSV Grafenberg Gegner";
+    protected static final Long MATCH_ID_GEGNER = 2L;
+    protected static final Long MATCH_SCHEIBENNUMMER_GEGNER = 4L;
+    protected static final Long MATCH_NAECHSTE_MATCH_ID = 1L;
+    protected static final Long MATCH_NAECHSTE_NAECHSTE_MATCH_ID = 1L;
+    protected static final Long MATCH_STRAFPUNKTE_SATZ_1 = 1L;
+    protected static final Long MATCH_STRAFPUNKTE_SATZ_2 = 2L;
+    protected static final Long MATCH_STRAFPUNKTE_SATZ_3 = 3L;
+    protected static final Long MATCH_STRAFPUNKTE_SATZ_4 = 4L;
+    protected static final Long MATCH_STRAFPUNKTE_SATZ_5 = 5L;
+
+    protected MatchDO getMatchDO() {
+        return new MatchDO(
+                MATCH_ID,
+                MATCH_NR,
+                MATCH_WETTKAMPF_ID,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_BEGEGNUNG,
+                MATCH_MATCHPUNKTE,
+                MATCH_SCHEIBENNUMMER,
+                MATCH_SATZPUNKTE,
+                MATCH_STRAFPUNKTE_SATZ_1,
+                MATCH_STRAFPUNKTE_SATZ_2,
+                MATCH_STRAFPUNKTE_SATZ_3,
+                MATCH_STRAFPUNKTE_SATZ_4,
+                MATCH_STRAFPUNKTE_SATZ_5
+        );
+    }
+
+    @Test
+    public void fromMatchDOtoDTO() {
+        MatchDO matchDO = getMatchDO();
+        final LigaSyncMatchDTO actual = LigaSyncMatchDTOMapper.fromMatchDOtoDTO.apply(matchDO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+}

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/model/SyncWrapperTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/model/SyncWrapperTest.java
@@ -1,0 +1,54 @@
+package de.bogenliga.application.services.v1.Sync.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import de.bogenliga.application.services.v1.Sync.service.SyncServiceTest;
+import de.bogenliga.application.services.v1.sync.model.LigaSyncMannschaftsmitgliedDTO;
+import de.bogenliga.application.services.v1.sync.model.LigaSyncMatchDTO;
+import de.bogenliga.application.services.v1.sync.model.LigaSyncPasseDTO;
+import de.bogenliga.application.services.v1.sync.model.SyncWrapper;
+import de.bogenliga.application.services.v1.sync.model.WettkampfExtDTO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jonas Sigloch
+ */
+public class SyncWrapperTest {
+    private static final List<LigaSyncMannschaftsmitgliedDTO> mitgliedList = new ArrayList<>(Collections.singletonList(
+            new LigaSyncMannschaftsmitgliedDTO(1000L, 2L, 1001L, 1202L, 3L)));
+    private static final List<LigaSyncMatchDTO> matchList = new ArrayList<>(Collections.singletonList(SyncServiceTest.getLigaSyncMatchDTO()));
+    private static final List<LigaSyncPasseDTO> passeList = new ArrayList<>(Collections.singletonList(SyncServiceTest.getLigaSyncPasseDTO()));
+    private static final String offlineToken = "testToken";
+    private static final long wettkampfId = 1009L;
+
+
+    private SyncWrapper getSyncWrapper() {
+        return new SyncWrapper(matchList, passeList, mitgliedList, offlineToken, wettkampfId);
+    }
+
+    @Test
+    public void checkWrapper() {
+        SyncWrapper undertest = getSyncWrapper();
+
+        assertThat(undertest).isNotNull();
+        assertThat(undertest.getWettkampfId()).isEqualTo(wettkampfId);
+        assertThat(undertest.getOfflineToken()).isEqualTo(offlineToken);
+        assertThat(undertest.getMannschaftsmitglied()).hasSize(1);
+        assertThat(undertest.getMatch()).hasSize(1);
+        assertThat(undertest.getPasse()).hasSize(1);
+    }
+
+    @Test
+    public void assertToString() {
+        final SyncWrapper underTest = getSyncWrapper();
+        final String actual = underTest.toString();
+
+        assertThat(actual)
+                .isNotEmpty()
+                .contains(Long.toString(wettkampfId))
+                .contains(offlineToken);
+    }
+}

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
@@ -36,6 +36,7 @@ import de.bogenliga.application.services.v1.match.model.MatchDTO;
 import de.bogenliga.application.services.v1.match.service.MatchService;
 import de.bogenliga.application.services.v1.passe.mapper.PasseDTOMapper;
 import de.bogenliga.application.services.v1.passe.model.PasseDTO;
+import de.bogenliga.application.services.v1.sync.model.LigaSyncMannschaftsmitgliedDTO;
 import de.bogenliga.application.services.v1.sync.model.LigaSyncMatchDTO;
 import de.bogenliga.application.services.v1.sync.model.LigaSyncLigatabelleDTO;
 import de.bogenliga.application.services.v1.sync.model.LigaSyncPasseDTO;
@@ -260,9 +261,9 @@ public class SyncServiceTest {
         return new MatchDO(
                 MATCH_ID,
                 MATCH_NR,
-                MATCH_BEGEGNUNG,
-                MATCH_MANNSCHAFT_ID,
                 MATCH_WETTKAMPF_ID,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_BEGEGNUNG,
                 MATCH_MATCHPUNKTE,
                 MATCH_SCHEIBENNUMMER,
                 MATCH_SATZPUNKTE,
@@ -734,42 +735,28 @@ public class SyncServiceTest {
                 .isThrownBy(() -> underTest.findByWettkampfId(-1));
     }
 
-    /*
     @Test
     public void testGetMannschaftsmitgliedernOffline() {
         MatchDO matchDO = getMatchDO();
-        //matchDOMock = mock(MatchDO);
         MannschaftsmitgliedDO mannschaftsmitgliedDO = getMannschaftsmitgliedDO();
-        MannschaftsmitgliedDO mannschaftsmitgliedDOMock = mock(mannschaftsmitgliedDO.getClass());
-        MannschaftsmitgliedComponent mannschaftsmitgliedComponentMock = mock(MannschaftsmitgliedComponent.class);
-        MatchComponent matchComponentMock = mock(MatchComponent.class);
 
         long scheibenNummer = 1;
-        List<MannschaftsmitgliedDO> mannschaftsmitgliedDOList = Collections.singletonList(mannschaftsmitgliedDOMock);
-        //when(matchComponent.findByWettkampfIDMatchNrScheibenNr(anyLong(), anyLong(), anyLong())).thenReturn(matchDO);
-        //when(mannschaftsmitgliedComponent.findSchuetzenInUebergelegenerLiga(anyLong(), anyLong())).thenReturn(mannschaftsmitgliedDOList);
-
-        //Mockito.verify(matchComponent, times(8));
-        //Mockito.verify(mannschaftsmitgliedComponent, times(8));
+        List<MannschaftsmitgliedDO> mannschaftsmitgliedDOList = Collections.singletonList(mannschaftsmitgliedDO);
+        when(matchComponent.findByWettkampfIDMatchNrScheibenNr(anyLong(), eq(1L), anyLong())).thenReturn(matchDO);
+        when(mannschaftsmitgliedComponent.findSchuetzenInUebergelegenerLiga(anyLong(), anyLong())).thenReturn(mannschaftsmitgliedDOList);
 
         final List<LigaSyncMannschaftsmitgliedDTO> actualMannschaftsmitgliedDOList = underTest.getMannschaftsmitgliedernOffline(wettkampfId);
         LigaSyncMannschaftsmitgliedDTO mannschaftsmitgliedDTO = actualMannschaftsmitgliedDOList.get(0);
         assertThat(actualMannschaftsmitgliedDOList).isNotNull().hasSize(8);
 
-        //UserService userService = mock(UserService.class);
-        //User user = mock(User.class);
-        //when(userService.getUserById(anyLong())).thenReturn(user);
-
-        assertThat(mannschaftsmitgliedDTO.getId().equals(mannschaftsmitgliedDO.getId()));
-        assertThat(mannschaftsmitgliedDTO.getMannschaftId().equals(mannschaftsmitgliedDO.getMannschaftId()));
-        assertThat(mannschaftsmitgliedDTO.getDsbMitgliedId().equals(mannschaftsmitgliedDO.getDsbMitgliedId()));
+        assertThat(mannschaftsmitgliedDTO.getId()).isEqualTo(mannschaftsmitgliedDO.getId());
+        assertThat(mannschaftsmitgliedDTO.getMannschaftId()).isEqualTo(mannschaftsmitgliedDO.getMannschaftId());
+        assertThat(mannschaftsmitgliedDTO.getDsbMitgliedId()).isEqualTo(mannschaftsmitgliedDO.getDsbMitgliedId());
 
         //verify invocations
         verify(matchComponent).findByWettkampfIDMatchNrScheibenNr(wettkampfId, 1L, scheibenNummer);
-        verify(mannschaftsmitgliedComponent).findSchuetzenInUebergelegenerLiga(mannschaftsId, wettkampfId);
-        Preconditions.checkArgument(wettkampfId >= 0, PRECONDITION_MSG_WETTKAMPF_ID);
+        verify(mannschaftsmitgliedComponent, times(8)).findSchuetzenInUebergelegenerLiga(any(), any());
     }
-    */
 
     @Test
     public void update() {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
@@ -463,7 +463,7 @@ public class SyncServiceTest {
 
     }
 
-    private static LigaSyncMatchDTO getLigaSyncMatchDTO() {
+    public static LigaSyncMatchDTO getLigaSyncMatchDTO() {
         return new LigaSyncMatchDTO (
                 MATCH_ID,
                 version,
@@ -511,7 +511,7 @@ public class SyncServiceTest {
         );
     }
 
-    private static LigaSyncPasseDTO getLigaSyncPasseDTO() {
+    public static LigaSyncPasseDTO getLigaSyncPasseDTO() {
         return new LigaSyncPasseDTO (
                 PASSE_ID,
                 VERSION,

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -174,9 +174,9 @@ public class MatchServiceTest {
         return new MatchDO(
                 MATCH_ID,
                 MATCH_NR,
-                MATCH_BEGEGNUNG,
-                MATCH_MANNSCHAFT_ID,
                 MATCH_WETTKAMPF_ID,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_BEGEGNUNG,
                 MATCH_MATCHPUNKTE,
                 MATCH_SCHEIBENNUMMER,
                 MATCH_SATZPUNKTE,


### PR DESCRIPTION
BSAPP-1140: BegegnungNr und WettkampfId der getMatchDO()-Methode waren vertauscht. LigaSyncMatchDTO-Mapper hinzugefügt. testGetMannschaftsmitgliedernOffline()-Methode
hinzugefügt