### PR TITLE
BSAPP-1140: testgetLigatabelleVeranstaltungToString() und Test zur Li…

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/mapper/LigaSyncMatchDTOMapper.java
@@ -38,7 +38,7 @@ public class LigaSyncMatchDTOMapper implements DataTransferObjectMapper {
         final Long version = matchDO.getVersion();
         final Long wettkampfId = matchDO.getWettkampfId();
         final Integer matchNr = Math.toIntExact(matchDO.getNr());
-        final Integer matchScheibennummer = Math.toIntExact(matchDO.getScheibenNummer());
+        final Integer matchScheibennummer = matchDO.getScheibenNummer()!=null ? Math.toIntExact(matchDO.getScheibenNummer()) : null;
         final Long matchpunkte = matchDO.getMatchpunkte()!=null ? matchDO.getMatchpunkte() : null;
         final Long satzpunkte = matchDO.getSatzpunkte()!=null ? matchDO.getSatzpunkte() : null;
         final Long mannschaftsId = matchDO.getMannschaftId();

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/mapper/LigaSyncMatchDTOMapperTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/mapper/LigaSyncMatchDTOMapperTest.java
@@ -3,6 +3,7 @@ package de.bogenliga.application.services.v1.Sync.mapper;
 import org.junit.Test;
 import de.bogenliga.application.business.match.api.types.LigamatchDO;
 import de.bogenliga.application.business.match.api.types.MatchDO;
+import de.bogenliga.application.services.v1.match.model.MatchDTO;
 import de.bogenliga.application.services.v1.sync.mapper.LigaSyncMatchDTOMapper;
 import de.bogenliga.application.services.v1.sync.model.LigaSyncMatchDTO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,10 +52,162 @@ public class LigaSyncMatchDTOMapperTest {
         );
     }
 
+    protected MatchDO getMatchDOWithNull() {
+        return new MatchDO(
+                MATCH_ID,
+                MATCH_NR,
+                MATCH_WETTKAMPF_ID,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_BEGEGNUNG,
+                null,
+                MATCH_SCHEIBENNUMMER,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private static LigaSyncMatchDTO getLigaSyncMatchDTO() {
+        return new LigaSyncMatchDTO (
+                MATCH_ID,
+                version,
+                MATCH_WETTKAMPF_ID,
+                MATCH_NR.intValue(),
+                MATCH_SCHEIBENNUMMER.intValue(),
+                MATCH_MATCHPUNKTE,
+                MATCH_SATZPUNKTE,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_MANNSCHAFT_NAME,
+                MATCH_NAME_GEGNER,
+                MATCH_SCHEIBENNUMMER_GEGNER.intValue(),
+                MATCH_ID_GEGNER,
+                MATCH_NAECHSTE_MATCH_ID,
+                MATCH_NAECHSTE_NAECHSTE_MATCH_ID,
+                MATCH_STRAFPUNKTE_SATZ_1.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_2.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_3.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_4.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_5.intValue()
+        );
+    }
+
+    private static LigaSyncMatchDTO getLigaSyncMatchDTOWithNull() {
+        return new LigaSyncMatchDTO (
+                MATCH_ID,
+                version,
+                MATCH_WETTKAMPF_ID,
+                MATCH_NR.intValue(),
+                MATCH_SCHEIBENNUMMER.intValue(),
+                MATCH_MATCHPUNKTE,
+                MATCH_SATZPUNKTE,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_MANNSCHAFT_NAME,
+                MATCH_NAME_GEGNER,
+                MATCH_SCHEIBENNUMMER_GEGNER.intValue(),
+                MATCH_ID_GEGNER,
+                MATCH_NAECHSTE_MATCH_ID,
+                MATCH_NAECHSTE_NAECHSTE_MATCH_ID,
+                MATCH_STRAFPUNKTE_SATZ_1.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_2.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_3.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_4.intValue(),
+                MATCH_STRAFPUNKTE_SATZ_5.intValue()
+        );
+    }
+
+    protected LigamatchDO getLigamatchDO() {
+        return new LigamatchDO(
+                MATCH_ID,
+                MATCH_WETTKAMPF_ID,
+                MATCH_NR,
+                MATCH_SCHEIBENNUMMER,
+                MATCH_MATCHPUNKTE,
+                MATCH_SATZPUNKTE,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_MANNSCHAFT_NAME,
+                MATCH_NAME_GEGNER,
+                MATCH_SCHEIBENNUMMER_GEGNER,
+                MATCH_ID_GEGNER,
+                MATCH_NAECHSTE_MATCH_ID,
+                MATCH_NAECHSTE_NAECHSTE_MATCH_ID,
+                MATCH_STRAFPUNKTE_SATZ_1,
+                MATCH_STRAFPUNKTE_SATZ_2,
+                MATCH_STRAFPUNKTE_SATZ_3,
+                MATCH_STRAFPUNKTE_SATZ_4,
+                MATCH_STRAFPUNKTE_SATZ_5
+        );
+    }
+
+    protected LigamatchDO getLigamatchDOWithNull() {
+        return new LigamatchDO(
+                MATCH_ID,
+                MATCH_WETTKAMPF_ID,
+                MATCH_NR,
+                MATCH_SCHEIBENNUMMER,
+                null,
+                null,
+                MATCH_MANNSCHAFT_ID,
+                MATCH_MANNSCHAFT_NAME,
+                MATCH_NAME_GEGNER,
+                null,
+                MATCH_ID_GEGNER,
+                MATCH_NAECHSTE_MATCH_ID,
+                MATCH_NAECHSTE_NAECHSTE_MATCH_ID,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
     @Test
     public void fromMatchDOtoDTO() {
         MatchDO matchDO = getMatchDO();
         final LigaSyncMatchDTO actual = LigaSyncMatchDTOMapper.fromMatchDOtoDTO.apply(matchDO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+
+    @Test
+    public void fromMatchDOWithNulltoDTO() {
+        MatchDO matchDO = getMatchDOWithNull();
+        final LigaSyncMatchDTO actual = LigaSyncMatchDTOMapper.fromMatchDOtoDTO.apply(matchDO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+
+    @Test
+    public void toDTO() {
+        LigamatchDO ligamatchDO = getLigamatchDO();
+        final LigaSyncMatchDTO actual = LigaSyncMatchDTOMapper.toDTO.apply(ligamatchDO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+
+    @Test
+    public void toDTOWithNull() {
+        LigamatchDO ligamatchDO = getLigamatchDOWithNull();
+        final LigaSyncMatchDTO actual = LigaSyncMatchDTOMapper.toDTO.apply(ligamatchDO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+
+    @Test
+    public void toMatchDTO() {
+        LigaSyncMatchDTO ligaSyncMatchDTO = getLigaSyncMatchDTO();
+        final MatchDTO actual = LigaSyncMatchDTOMapper.toMatchDTO.apply(ligaSyncMatchDTO);
+        assertThat(actual.getId()).isEqualTo(MATCH_ID);
+        assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
+    }
+
+    @Test
+    public void toMatchDTOWithNull() {
+        LigaSyncMatchDTO ligaSyncMatchDTO = getLigaSyncMatchDTOWithNull();
+        final MatchDTO actual = LigaSyncMatchDTOMapper.toMatchDTO.apply(ligaSyncMatchDTO);
         assertThat(actual.getId()).isEqualTo(MATCH_ID);
         assertThat(actual.getWettkampfId()).isEqualTo(MATCH_WETTKAMPF_ID);
     }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
@@ -189,6 +189,7 @@ public class SyncServiceTest {
     private static final Long wettkampfId = 2L;
     private static final int wettkampfTag = 3;
     private static final Long mannschaftId = 4L;
+    private static final String mannschaftName = "GegnerMannschaft";
     private static final int mannschaftNummer = 9;
     private static final Long vereinId = 7L;
     private static final String vereinName = "Name_Verein";
@@ -538,9 +539,39 @@ public class SyncServiceTest {
         );
     }
 
+    private static LigaSyncLigatabelleDTO getLigaSyncLigatabelleDTO() {
+        return new LigaSyncLigatabelleDTO (
+                veranstaltungId,
+                veranstaltungName,
+                wettkampfId,
+                wettkampfTag,
+                mannschaftId,
+                mannschaftName,
+                matchpkt,
+                matchpktGegen,
+                satzpkt,
+                satzpktGegen,
+                satzpktDifferenz,
+                sortierung,
+                tabellenplatz
+        );
+    }
+
     @Before
     public void initMocks() {
         when(principal.getName()).thenReturn(String.valueOf(CURRENT_USER_ID));
+    }
+
+    @Test
+    public void testgetLigatabelleVeranstaltungToString() {
+        final LigaSyncLigatabelleDTO ligaSyncLigatabelleDTO = getLigaSyncLigatabelleDTO();
+        final String actual = ligaSyncLigatabelleDTO.toString();
+
+        assertThat(actual)
+                .isNotEmpty()
+                .contains(Long.toString(veranstaltungId))
+                .contains(Long.toString(wettkampfId))
+                .contains(Long.toString(mannschaftId));
     }
 
     @Test
@@ -570,6 +601,8 @@ public class SyncServiceTest {
         verify(ligatabelleComponent).getLigatabelleVeranstaltung(wettkampfId);
         Preconditions.checkArgument(wettkampfId >= 0, PRECONDITION_MSG_VERANSTALTUNG_ID);
     }
+
+
 
     @Test
     public void testFindByWettkampfId() {


### PR DESCRIPTION
…gaSyncMatchDTOMapperTest-Klasse für höhere Condition-Abdeckung hinzugefügt.

Fehlerbehebung wenn MatchDO Scheibennumemr null ist.