### PR TITLE
[Fix to flyway script V68] Remove reference to possibly non-existent table altsystem_acl

### DIFF
--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/LOCAL/V68_0__Insert_from_bl_db.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/LOCAL/V68_0__Insert_from_bl_db.sql
@@ -51,9 +51,6 @@ INSERT INTO altsystem_saison VALUES (1,'2017 - 2018',1,0),(2,'2018 - 2019',1,0),
 /*!40000 ALTER TABLE `saison` ENABLE KEYS */;
 COMMIT;
 
--- Löschen des abhängigen Fremdschlüssel-Constraints in der Tabelle "acl"
-ALTER TABLE altsystem_acl DROP CONSTRAINT IF EXISTS altsystem_fk_acl_users_id;
-
 -- Löschen der Tabelle "users" und der Sequenz
 DROP TABLE IF EXISTS altsystem_users CASCADE;
 


### PR DESCRIPTION
Flyway script V68 is currently blocking all following scripts due to an error.

![image](https://github.com/bettercodepaul/swt2-bsa-backend/assets/147146620/3a165fa4-d84e-49a8-b039-e8179a7e69fe)


![image](https://github.com/bettercodepaul/swt2-bsa-backend/assets/147146620/5fcf94b3-d68f-4bb3-bc6e-89f48d4b3db5)


By removing the reference to `altsystem_acl`, the script now behaves as intended, regardless of whether `altsystem_acl` exists or not. If the foreign key *does* already exist, it gets deleted automatically, as can be seen in the following log output from running V68 with this PR's changes:

![image](https://github.com/bettercodepaul/swt2-bsa-backend/assets/147146620/bece4fa4-9fed-4b73-a323-da94b836f3c3)

This confirms the validity of this PR.