### PR TITLE
Migration umstellen - Status der Veranstaltung abhängig von der Relation Sportjahr zu aktives-Sportjahr aus Config

### DIFF
--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/DEV/V7_0__update_Veranstaltung_wg_migration.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/DEV/V7_0__update_Veranstaltung_wg_migration.sql
@@ -1,0 +1,24 @@
+/*Geplant = 1, Laufend = 2, Abgeschlossen = 3
+wir überarbeiten nur Veranstaltungen die aktuell im Status "geplant" sind
+  da die Migration vor dem Bugfix alle Veranstaltungen mit Phase geplant
+  angelegt hat...*/
+
+-- die geplanten müssen nicht geändert werden...
+
+-- die abgeschlossenen haben ein Sportjahr vor/kleiner dem aktiven Sportjahr
+update veranstaltung
+set veranstaltung_phase = 3
+    from (select veranstaltung_id from veranstaltung, configuration
+      where veranstaltung_sportjahr < CAST(configuration_value AS NUMERIC)
+        and configuration_key = 'aktives-Sportjahr'
+        and veranstaltung_phase = 1) as subquery
+where subquery.veranstaltung_id = veranstaltung.veranstaltung_id;
+
+-- und  die laufenden sportjahr = aktives Sportjahr
+update veranstaltung
+set veranstaltung_phase = 2
+    from (select veranstaltung_id from veranstaltung, configuration
+      where veranstaltung_sportjahr = CAST(configuration_value AS NUMERIC)
+        and configuration_key = 'aktives-Sportjahr'
+        and veranstaltung_phase = 1) as subquery
+where subquery.veranstaltung_id = veranstaltung.veranstaltung_id;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemVeranstaltungMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemVeranstaltungMapper.java
@@ -3,6 +3,8 @@ package de.bogenliga.application.business.altsystem.mannschaft.mapper;
 import java.sql.Date;
 import java.util.List;
 
+import de.bogenliga.application.business.configuration.api.ConfigurationComponent;
+import de.bogenliga.application.business.configuration.api.types.ConfigurationDO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import de.bogenliga.application.business.altsystem.uebersetzung.AltsystemUebersetzungDO;
@@ -32,6 +34,7 @@ public class AltsystemVeranstaltungMapper {
     private final LigaComponent ligaComponent;
     private final WettkampfTypComponent wettkampfTypComponent;
     private final DsbMannschaftComponent dsbMannschaftComponent;
+    private final ConfigurationComponent configurationComponent;
     private final AltsystemUebersetzung altsystemUebersetzung;
 
     /**
@@ -47,11 +50,14 @@ public class AltsystemVeranstaltungMapper {
     @Autowired
     public AltsystemVeranstaltungMapper(final VeranstaltungComponent veranstaltungComponent,
                                         LigaComponent ligaComponent, WettkampfTypComponent wettkampfTypComponent,
-                                        DsbMannschaftComponent dsbMannschaftComponent, AltsystemUebersetzung altsystemUebersetzung) {
+                                        DsbMannschaftComponent dsbMannschaftComponent,
+                                        ConfigurationComponent configurationComponent,
+                                        AltsystemUebersetzung altsystemUebersetzung) {
         this.veranstaltungComponent = veranstaltungComponent;
         this.ligaComponent = ligaComponent;
         this.wettkampfTypComponent = wettkampfTypComponent;
         this.dsbMannschaftComponent = dsbMannschaftComponent;
+        this.configurationComponent = configurationComponent;
         this.altsystemUebersetzung = altsystemUebersetzung;
     }
 
@@ -128,8 +134,19 @@ public class AltsystemVeranstaltungMapper {
         veranstaltungDO.setVeranstaltungMeldeDeadline(meldeDeadline);
         // groesse: default als Mindestgroesse auf 4 gesetzt, später in getOrCreateVeranstaltung updated
         veranstaltungDO.setVeranstaltungGroesse(4);
-        // phase: "geplant" setzen
-        veranstaltungDO.setVeranstaltungPhase("Laufend");
+        // abhängig von dem Sportjahr der Veranstaltung und dem aktuellen Sportjahr
+        // in der BSAPP wird der Status gesetzt:
+
+        ConfigurationDO configurationDO = configurationComponent.findByKey("aktives-Sportjahr");
+        if (sportjahr < Long.parseLong(configurationDO.getValue()))
+            // Sportjahr < aktives Sportjahr --> abgeschlossen
+            veranstaltungDO.setVeranstaltungPhase("Abgeschlossen");
+        else if (sportjahr > Long.parseLong(configurationDO.getValue()))
+            // Sportjahr > aktives Sportjahr --> geplant
+            veranstaltungDO.setVeranstaltungPhase("Geplant");
+        else
+            // Sportjahr = aktives Sportjahr --> laufend
+            veranstaltungDO.setVeranstaltungPhase("Laufend");
         // Ligaleiter_id:
         veranstaltungDO.setVeranstaltungLigaleiterID(currentUserId);
         // Wettkampftyp: Satzsystem

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemVeranstaltungMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemVeranstaltungMapper.java
@@ -2,6 +2,7 @@ package de.bogenliga.application.business.altsystem.mannschaft.mapper;
 
 import java.sql.Date;
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import de.bogenliga.application.business.altsystem.uebersetzung.AltsystemUebersetzungDO;
@@ -128,7 +129,7 @@ public class AltsystemVeranstaltungMapper {
         // groesse: default als Mindestgroesse auf 4 gesetzt, später in getOrCreateVeranstaltung updated
         veranstaltungDO.setVeranstaltungGroesse(4);
         // phase: "geplant" setzen
-        veranstaltungDO.setVeranstaltungPhase("geplant");
+        veranstaltungDO.setVeranstaltungPhase("Laufend");
         // Ligaleiter_id:
         veranstaltungDO.setVeranstaltungLigaleiterID(currentUserId);
         // Wettkampftyp: Satzsystem

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
@@ -4,6 +4,9 @@ import java.sql.Date;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+
+import de.bogenliga.application.business.configuration.api.ConfigurationComponent;
+import de.bogenliga.application.business.configuration.api.types.ConfigurationDO;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -58,6 +61,8 @@ public class AltsystemVeranstaltungMapperTest {
     private WettkampfTypComponent wettkampfTypComponent;
     @Mock
     private DsbMannschaftComponent dsbMannschaftComponent;
+    @Mock
+    private ConfigurationComponent configurationComponent;
 
     @InjectMocks
     private AltsystemVeranstaltungMapper altsystemVeranstaltungMapper;
@@ -78,6 +83,10 @@ public class AltsystemVeranstaltungMapperTest {
         // Sportjahr uebersetzung
         AltsystemUebersetzungDO sportjahrUebersetzung = new AltsystemUebersetzungDO();
         sportjahrUebersetzung.setWert(String.valueOf(SPORTJAHR));
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2022");
 
         // expected Result
         VeranstaltungDO expectedVeranstaltungDO = new VeranstaltungDO();
@@ -100,6 +109,7 @@ public class AltsystemVeranstaltungMapperTest {
         // Mock behavior of groesse
         when(dsbMannschaftComponent.findAllByVeranstaltungsId(anyLong())).thenReturn(getMockedDsbMannschaften());
 
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
         // Mock behavior of AltsystemUebersetzung.updateOrInsertUebersetzung
         doNothing().when(altsystemUebersetzung).updateOrInsertUebersetzung(any(), anyLong(), anyLong(), any());
 
@@ -132,6 +142,10 @@ public class AltsystemVeranstaltungMapperTest {
         // Sportjahr uebersetzung
         AltsystemUebersetzungDO sportjahrUebersetzung = new AltsystemUebersetzungDO();
         sportjahrUebersetzung.setWert(String.valueOf(SPORTJAHR));
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2022");
 
         // expected Result
         VeranstaltungDO expectedVeranstaltungDO = new VeranstaltungDO();
@@ -150,6 +164,7 @@ public class AltsystemVeranstaltungMapperTest {
         when(veranstaltungComponent.findByLigaIDAndSportjahr(anyLong(), anyLong())).thenThrow(new BusinessException(
                 ErrorCode.ENTITY_NOT_FOUND_ERROR, "Test"));
 
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
         // Mock behavior of altsystemVeranstaltungMapper.createVeranstaltung
         doReturn(expectedVeranstaltungDO).when(altsystemVeranstaltungMapper1).createVeranstaltung(ligaUebersetzung.getBogenligaId(), Long.parseLong(sportjahrUebersetzung.getWert()), CURRENTUSERID);
 
@@ -168,6 +183,10 @@ public class AltsystemVeranstaltungMapperTest {
         LigaDO mockedLigaDO = new LigaDO();
         mockedLigaDO.setId(LIGAID);
         mockedLigaDO.setName("TestLiga");
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2022");
 
         // Mock behavior of ligaComponent.findById
         when(ligaComponent.findById(LIGAID)).thenReturn(mockedLigaDO);
@@ -178,6 +197,7 @@ public class AltsystemVeranstaltungMapperTest {
         // Mock behavior of veranstaltungComponent.create()
         when(veranstaltungComponent.create(any(VeranstaltungDO.class), eq(CURRENTUSERID)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
 
         // Call test method
         VeranstaltungDO result = altsystemVeranstaltungMapper.createVeranstaltung(LIGAID, SPORTJAHR, CURRENTUSERID);
@@ -188,7 +208,7 @@ public class AltsystemVeranstaltungMapperTest {
         assertEquals((Long)SPORTJAHR, result.getVeranstaltungSportJahr());
         assertEquals(Date.valueOf("2021-10-01"), result.getVeranstaltungMeldeDeadline());
         assertEquals((Integer) 4, result.getVeranstaltungGroesse());
-        assertEquals("geplant", result.getVeranstaltungPhase());
+        assertEquals("Laufend", result.getVeranstaltungPhase());
         assertEquals((Long)CURRENTUSERID, result.getVeranstaltungLigaleiterID());
         assertEquals((Long) WETTKAMPFTYP_ID, result.getVeranstaltungWettkampftypID());
         assertEquals(WETTKAMPFTYP_NAME, result.getVeranstaltungWettkampftypName());
@@ -212,6 +232,10 @@ public class AltsystemVeranstaltungMapperTest {
         // Sportjahr uebersetzung
         AltsystemUebersetzungDO sportjahrUebersetzung = new AltsystemUebersetzungDO();
         sportjahrUebersetzung.setWert(String.valueOf(SPORTJAHR));
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2022");
 
         // expected Result
         VeranstaltungDO expectedVeranstaltungDO = new VeranstaltungDO();
@@ -236,6 +260,7 @@ public class AltsystemVeranstaltungMapperTest {
 
         // Mock behavior of veranstaltungComponent.update()
         when(veranstaltungComponent.update(expectedVeranstaltungDO, CURRENTUSERID)).thenReturn(expectedVeranstaltungDO);
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
 
         // Mock behavior of AltsystemUebersetzung.updateOrInsertUebersetzung
         doNothing().when(altsystemUebersetzung).updateOrInsertUebersetzung(any(), anyLong(), anyLong(), any());
@@ -268,6 +293,10 @@ public class AltsystemVeranstaltungMapperTest {
         // Sportjahr uebersetzung
         AltsystemUebersetzungDO sportjahrUebersetzung = new AltsystemUebersetzungDO();
         sportjahrUebersetzung.setWert(String.valueOf(SPORTJAHR));
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2022");
 
         // expected Result
         VeranstaltungDO expectedVeranstaltungDO = new VeranstaltungDO();
@@ -286,6 +315,7 @@ public class AltsystemVeranstaltungMapperTest {
         // Mock behavior of veranstaltungComponent.findByLigaIDAndSportjahr
         when(veranstaltungComponent.findByLigaIDAndSportjahr(LIGAID, SPORTJAHR))
                 .thenReturn(expectedVeranstaltungDO);
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
 
         // Mock behavior of groesse
         when(dsbMannschaftComponent.findAllByVeranstaltungsId(anyLong())).thenReturn(get6MockedDsbMannschaften());

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
@@ -125,7 +125,7 @@ public class AltsystemVeranstaltungMapperTest {
 
     }
 
-    // tests getOrCreateVeranstaltung when try/catch throws exception
+     // tests getOrCreateVeranstaltung when try/catch throws exception
     @Test
     public void testTryCatch() {
         AltsystemVeranstaltungMapper altsystemVeranstaltungMapper1 = Mockito.spy(altsystemVeranstaltungMapper);
@@ -209,6 +209,85 @@ public class AltsystemVeranstaltungMapperTest {
         assertEquals(Date.valueOf("2021-10-01"), result.getVeranstaltungMeldeDeadline());
         assertEquals((Integer) 4, result.getVeranstaltungGroesse());
         assertEquals("Laufend", result.getVeranstaltungPhase());
+        assertEquals((Long)CURRENTUSERID, result.getVeranstaltungLigaleiterID());
+        assertEquals((Long) WETTKAMPFTYP_ID, result.getVeranstaltungWettkampftypID());
+        assertEquals(WETTKAMPFTYP_NAME, result.getVeranstaltungWettkampftypName());
+
+
+    }
+    // tests createVeranstaltung
+    @Test
+    public void testCreateVeranstaltung_geplant() {
+        // prepare test data
+        // Mock Liga
+        LigaDO mockedLigaDO = new LigaDO();
+        mockedLigaDO.setId(LIGAID);
+        mockedLigaDO.setName("TestLiga");
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2020");
+
+        // Mock behavior of ligaComponent.findById
+        when(ligaComponent.findById(LIGAID)).thenReturn(mockedLigaDO);
+
+        // Mock behavior of getSatzSystemDO()
+        when(wettkampfTypComponent.findAll()).thenReturn(getMockedWettkampfTypen());
+
+        // Mock behavior of veranstaltungComponent.create()
+        when(veranstaltungComponent.create(any(VeranstaltungDO.class), eq(CURRENTUSERID)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
+
+        // Call test method
+        VeranstaltungDO result = altsystemVeranstaltungMapper.createVeranstaltung(LIGAID, SPORTJAHR, CURRENTUSERID);
+
+        // assert result
+        assertEquals("TestLiga " + SPORTJAHR, result.getVeranstaltungName());
+        assertEquals((Long)LIGAID, result.getVeranstaltungLigaID());
+        assertEquals((Long)SPORTJAHR, result.getVeranstaltungSportJahr());
+        assertEquals(Date.valueOf("2021-10-01"), result.getVeranstaltungMeldeDeadline());
+        assertEquals((Integer) 4, result.getVeranstaltungGroesse());
+        assertEquals("Geplant", result.getVeranstaltungPhase());
+        assertEquals((Long)CURRENTUSERID, result.getVeranstaltungLigaleiterID());
+        assertEquals((Long) WETTKAMPFTYP_ID, result.getVeranstaltungWettkampftypID());
+        assertEquals(WETTKAMPFTYP_NAME, result.getVeranstaltungWettkampftypName());
+
+
+    }
+    @Test
+    public void testCreateVeranstaltung_abgeschlossen() {
+        // prepare test data
+        // Mock Liga
+        LigaDO mockedLigaDO = new LigaDO();
+        mockedLigaDO.setId(LIGAID);
+        mockedLigaDO.setName("TestLiga");
+        // aktives Sportjahr aus Configuration
+        ConfigurationDO configurationDO = new ConfigurationDO();
+        configurationDO.setKey("aktives-Sportjahr");
+        configurationDO.setValue("2024");
+
+        // Mock behavior of ligaComponent.findById
+        when(ligaComponent.findById(LIGAID)).thenReturn(mockedLigaDO);
+
+        // Mock behavior of getSatzSystemDO()
+        when(wettkampfTypComponent.findAll()).thenReturn(getMockedWettkampfTypen());
+
+        // Mock behavior of veranstaltungComponent.create()
+        when(veranstaltungComponent.create(any(VeranstaltungDO.class), eq(CURRENTUSERID)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(configurationComponent.findByKey("aktives-Sportjahr")).thenReturn(configurationDO);
+
+        // Call test method
+        VeranstaltungDO result = altsystemVeranstaltungMapper.createVeranstaltung(LIGAID, SPORTJAHR, CURRENTUSERID);
+
+        // assert result
+        assertEquals("TestLiga " + SPORTJAHR, result.getVeranstaltungName());
+        assertEquals((Long)LIGAID, result.getVeranstaltungLigaID());
+        assertEquals((Long)SPORTJAHR, result.getVeranstaltungSportJahr());
+        assertEquals(Date.valueOf("2021-10-01"), result.getVeranstaltungMeldeDeadline());
+        assertEquals((Integer) 4, result.getVeranstaltungGroesse());
+        assertEquals("Abgeschlossen", result.getVeranstaltungPhase());
         assertEquals((Long)CURRENTUSERID, result.getVeranstaltungLigaleiterID());
         assertEquals((Long) WETTKAMPFTYP_ID, result.getVeranstaltungWettkampftypID());
         assertEquals(WETTKAMPFTYP_NAME, result.getVeranstaltungWettkampftypName());


### PR DESCRIPTION
Abschluss der Bugfixes zur Migration:
- die Daten werden aktuell noch nicht in der Umgebung angezeigt, da die Migration alle Veranstaltungen als "geplant" anlegt.
- der Statusübergang ist bei den übernommenen Veranstaltungen aber nicht möglich (keine Generierung von Matches)
- gem. Vorgabe Gero ist die Abbildung Sportjahr > aktives Sportjahr --> geplant, Sportjahr < akt.Sportjahr --> abgeschlossen, sonst laufend
- Bugfix mit Anpassung der Migration, zugehöriger Tests und einem SQl_Skript, das auf DEV die Daten korrigiert
- keine Korrektur auf "Lokal" - da manuell möglich, keine auf Prod --> keine Daten vorhanden