### PR TITLE
Bugfix für die Übernahme von Schützenergebnissen in die Passen-Pfeilwerte

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/ergebnisse/dataobject/AltsystemErgebnisseDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/ergebnisse/dataobject/AltsystemErgebnisseDO.java
@@ -11,7 +11,7 @@ public class AltsystemErgebnisseDO extends AltsystemDO {
 
     private Long schuetze_id =null;
     private int match = 0;
-    private int ergebniss = 0;
+    private Long ergebniss = 0L;
 
 
     public Long getSchuetze_Id() { return schuetze_id; }
@@ -26,11 +26,9 @@ public class AltsystemErgebnisseDO extends AltsystemDO {
         this.match = match;
     }
 
-    public int getErgebnis() {
+    public Long getErgebniss() {
         return ergebniss;
     }
 
-    public void setErgebnis(int ergebniss) {
-        this.ergebniss = (ergebniss);
-    }
+    public void setErgebniss(Long ergebniss) {this.ergebniss = ergebniss; }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/ergebnisse/mapper/AltsystemPasseMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/ergebnisse/mapper/AltsystemPasseMapper.java
@@ -140,14 +140,14 @@ public class AltsystemPasseMapper {
         }
 
         // Exception, falls kein passendes Match gefunden wurde und ein Ergebnis >0 zu speichern ist
-        if (match.getId()== 0L && altsystemDataObject.getErgebnis()>0 ){
+        if (match.getId()== 0L && altsystemDataObject.getErgebniss()>0 ){
             throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND_ERROR, "When creating Passen Match for Mannschaft %s and MatchNr %s not found",dsbMannschaftDO.getId(),matchNr);
         }
         //keine Exception, wenn das Ergebnis = 0 ist
         //bei Gero werden alle Kombinationen von Schützen und Match in der Ergebnis-Tabelle abgelegt
         //in der Tabelle Wettkampf stehen aber nur Kombinationen für Schütze, die geschossen haben
         // da fehlen dann bei uns die Einträge in der Match-Tabelle
-        else if (match.getId()== 0L && altsystemDataObject.getErgebnis()==0) {
+        else if (match.getId()== 0L && altsystemDataObject.getErgebniss()==0) {
             // wir geben ein leeres Feld zurück - hier müssen keine Daten angelegt werden.
             return passen;
         }
@@ -157,7 +157,7 @@ public class AltsystemPasseMapper {
             AltsystemUebersetzungDO satzUebersetzung = altsystemUebersetzung.findByAltsystemID(AltsystemUebersetzungKategorie.Match_Saetze, match.getId());
             int anzahlSaetze = Integer.parseInt(satzUebersetzung.getWert());
 
-            int[][] punkte = getPassenpunkte(altsystemDataObject.getErgebnis(), anzahlSaetze);
+            int[][] punkte = getPassenpunkte(altsystemDataObject.getErgebniss(), anzahlSaetze);
 
             for (int i = 0; i < anzahlSaetze; i++) {
                 PasseDO passe = new PasseDO();
@@ -185,7 +185,7 @@ public class AltsystemPasseMapper {
      */
     public List<PasseDO> recalculatePassen(List<PasseDO> passen, AltsystemErgebnisseDO altsystemDataObject){
 
-        int[][] punkte = getPassenpunkte(altsystemDataObject.getErgebnis(), passen.size());
+        int[][] punkte = getPassenpunkte(altsystemDataObject.getErgebniss(), passen.size());
         for(int i = 0; i < passen.size(); i++){
             PasseDO passe = passen.get(i);
             passe.setPfeil1(punkte[i][0]);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/ergebnisse/entity/AltsystemErgebnisseTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/ergebnisse/entity/AltsystemErgebnisseTest.java
@@ -45,7 +45,7 @@ public class AltsystemErgebnisseTest {
         AltsystemErgebnisseDO altsystemErgebnisseDO = new AltsystemErgebnisseDO();
         altsystemErgebnisseDO.setId(14L);
         altsystemErgebnisseDO.setSchuetze_Id(1L);
-        altsystemErgebnisseDO.setErgebnis(47);
+        altsystemErgebnisseDO.setErgebniss(47L);
         altsystemErgebnisseDO.setMatch(4);
 
         List<PasseDO> passen = new LinkedList<>();
@@ -69,7 +69,7 @@ public class AltsystemErgebnisseTest {
         AltsystemErgebnisseDO altsystemErgebnisseDO = new AltsystemErgebnisseDO();
         altsystemErgebnisseDO.setId(14L);
         altsystemErgebnisseDO.setSchuetze_Id(1L);
-        altsystemErgebnisseDO.setErgebnis(47);
+        altsystemErgebnisseDO.setErgebniss(47L);
         altsystemErgebnisseDO.setMatch(4);
 
         // Uebersetzung DO

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/ergebnisse/mapper/AltsystemPasseMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/ergebnisse/mapper/AltsystemPasseMapperTest.java
@@ -87,7 +87,7 @@ public class AltsystemPasseMapperTest{
         // Prepare Test data
         AltsystemErgebnisseDO altsystemErgebnisDO = new AltsystemErgebnisseDO();
         altsystemErgebnisDO.setId(5L);
-        altsystemErgebnisDO.setErgebnis(77);
+        altsystemErgebnisDO.setErgebniss(77L);
         altsystemErgebnisDO.setMatch(MATCH_NR);
         altsystemErgebnisDO.setSchuetze_Id(2L);
 
@@ -168,7 +168,7 @@ public class AltsystemPasseMapperTest{
         // Prepare Test data
         AltsystemErgebnisseDO altsystemErgebnisDO = new AltsystemErgebnisseDO();
         altsystemErgebnisDO.setId(5L);
-        altsystemErgebnisDO.setErgebnis(78);
+        altsystemErgebnisDO.setErgebniss(78L);
         altsystemErgebnisDO.setMatch(MATCH_NR);
         altsystemErgebnisDO.setSchuetze_Id(2L);
         DsbMannschaftDO dsbMannschaftDO = new DsbMannschaftDO(1L);
@@ -222,7 +222,7 @@ public class AltsystemPasseMapperTest{
         // Prepare Test data
         AltsystemErgebnisseDO altsystemErgebnisDO = new AltsystemErgebnisseDO();
         altsystemErgebnisDO.setId(5L);
-        altsystemErgebnisDO.setErgebnis(87);
+        altsystemErgebnisDO.setErgebniss(87L);
         altsystemErgebnisDO.setMatch(MATCH_NR);
         altsystemErgebnisDO.setSchuetze_Id(2L);
 


### PR DESCRIPTION
Das Wort Ergebniss überall gleich "falsch-geschrieben"