### PR TITLE
#1547 änderungsdaten filtermöglichkeiten erstellen epic api endpunkte(backend)

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -19,6 +19,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import de.bogenliga.application.business.altsystem.ergebnisse.dataobject.AltsystemErgebnisseDO;
 import de.bogenliga.application.business.altsystem.ergebnisse.entity.AltsystemErgebnisse;
@@ -144,29 +145,29 @@ public class TriggerService implements ServiceFacade {
     }
     @GetMapping("/findSuccessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllSuccessed() {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed();
+    public List<TriggerDTO> findAllSuccessed(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed(offsetMultiplicator, queryPageLimit);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findErrors")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllErrors() {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllErrors();
+    public List<TriggerDTO> findAllErrors(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllErrors(offsetMultiplicator, queryPageLimit);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findInProgress")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllInProgress() {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllInProgress();
+    public List<TriggerDTO> findAllInProgress(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllInProgress(offsetMultiplicator, queryPageLimit);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findNews")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllNews() {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews();
+    public List<TriggerDTO> findAllNews(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews(offsetMultiplicator, queryPageLimit);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -135,7 +135,13 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
+    @GetMapping("/findAllUnprocessed")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllUnprocesseed() {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllUnprocessed();
 
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
     public void setMigrationTimestamp(Timestamp timestamp){
         List<MigrationTimestampBE> timestamplist = migrationTimestampDAO.findAll();
         if (timestamplist.isEmpty()){

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -136,6 +136,13 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
+    @GetMapping("/findAllWithPages")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllWithPages(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllWithPages(offsetMultiplicator, queryPageLimit);
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
     @GetMapping("/findAllUnprocessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
     public List<TriggerDTO> findAllUnprocessed() {

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -142,6 +142,34 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
+    @GetMapping("/findSuccessed")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllSuccessed() {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed();
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
+    @GetMapping("/findErrors")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllErrors() {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllErrors();
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
+    @GetMapping("/findInProgress")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllInProgress() {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllInProgress();
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
+    @GetMapping("/findNews")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllNews() {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews();
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
     public void setMigrationTimestamp(Timestamp timestamp){
         List<MigrationTimestampBE> timestamplist = migrationTimestampDAO.findAll();
         if (timestamplist.isEmpty()){

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -135,13 +135,7 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
-    @GetMapping("/findAllUnprocessed")
-    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllUnprocesseed() {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllUnprocessed();
 
-        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
-    }
     public void setMigrationTimestamp(Timestamp timestamp){
         List<MigrationTimestampBE> timestamplist = migrationTimestampDAO.findAll();
         if (timestamplist.isEmpty()){

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -137,7 +137,7 @@ public class TriggerService implements ServiceFacade {
     }
     @GetMapping("/findAllUnprocessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllUnprocesseed() {
+    public List<TriggerDTO> findAllUnprocessed() {
         final List<TriggerDO> triggerDOList = triggerComponent.findAllUnprocessed();
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
@@ -16,13 +16,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.altsystem.liga.dataobject.AltsystemLigaDO;
-import de.bogenliga.application.business.liga.api.LigaComponent;
 import de.bogenliga.application.business.trigger.api.TriggerComponent;
 import de.bogenliga.application.business.trigger.api.types.TriggerChangeOperation;
 import de.bogenliga.application.business.trigger.api.types.TriggerChangeStatus;
 import de.bogenliga.application.business.trigger.api.types.TriggerDO;
 import de.bogenliga.application.business.trigger.impl.dao.MigrationTimestampDAO;
-import de.bogenliga.application.business.trigger.impl.dao.TriggerDAO;
 import de.bogenliga.application.business.trigger.impl.entity.MigrationTimestampBE;
 import de.bogenliga.application.common.altsystem.AltsystemDO;
 import de.bogenliga.application.common.component.dao.BasicDAO;
@@ -43,6 +41,10 @@ public class TriggerServiceTest {
 	private static final Long TRIGGER_ALTSYSTEMID = 234L;
 	private static final TriggerChangeOperation TRIGGER_OPERATION = null;
 	private static final TriggerChangeStatus TRIGGER_STATUS = null;
+	private static final TriggerChangeStatus TRIGGER_STATUS_ERROR = TriggerChangeStatus.ERROR;
+	private static final TriggerChangeStatus TRIGGER_STATUS_NEW = TriggerChangeStatus.NEW;
+	private static final TriggerChangeStatus TRIGGER_STATUS_SUCCSESS = TriggerChangeStatus.SUCCESS;
+	private static final TriggerChangeStatus TRIGGER_STATUS_IN_PROGRESS = TriggerChangeStatus.IN_PROGRESS;
 	private static final String TRIGGER_NACHRICHT = "see";
 	public static final OffsetDateTime TRIGGER_CREATEDATUTCO = null;
 	public static final OffsetDateTime TRIGGER_RUNATUTCO = null;
@@ -52,12 +54,9 @@ public class TriggerServiceTest {
 
 	@Mock
 	private BasicDAO basicDAO;
-	@Mock
-	private TriggerDAO triggerDAO;
+
 	@Mock
 	private TriggerComponent triggerComponent;
-	@Mock
-	private LigaComponent ligaComponent;
 	@Mock
 	private MigrationTimestampDAO migrationTimestampDAO;
 	@Mock
@@ -74,6 +73,54 @@ public class TriggerServiceTest {
 				TRIGGER_ALTSYSTEMID,
 				TRIGGER_OPERATION,
 				TRIGGER_STATUS,
+				TRIGGER_NACHRICHT,
+				TRIGGER_CREATEDATUTCO,
+				TRIGGER_RUNATUTCO
+		);
+	}
+	public static TriggerDO getErrorTriggerDO() {
+		return new TriggerDO(
+				TRIGGER_ID,
+				TRIGGER_KATEGORIE,
+				TRIGGER_ALTSYSTEMID,
+				TRIGGER_OPERATION,
+				TRIGGER_STATUS_ERROR,
+				TRIGGER_NACHRICHT,
+				TRIGGER_CREATEDATUTCO,
+				TRIGGER_RUNATUTCO
+		);
+	}
+	public static TriggerDO getNewTriggerDO() {
+		return new TriggerDO(
+				TRIGGER_ID,
+				TRIGGER_KATEGORIE,
+				TRIGGER_ALTSYSTEMID,
+				TRIGGER_OPERATION,
+				TRIGGER_STATUS_NEW,
+				TRIGGER_NACHRICHT,
+				TRIGGER_CREATEDATUTCO,
+				TRIGGER_RUNATUTCO
+		);
+	}
+	public static TriggerDO getSuccsessTriggerDO() {
+		return new TriggerDO(
+				TRIGGER_ID,
+				TRIGGER_KATEGORIE,
+				TRIGGER_ALTSYSTEMID,
+				TRIGGER_OPERATION,
+				TRIGGER_STATUS_SUCCSESS,
+				TRIGGER_NACHRICHT,
+				TRIGGER_CREATEDATUTCO,
+				TRIGGER_RUNATUTCO
+		);
+	}
+	public static TriggerDO getInProgressTriggerDO() {
+		return new TriggerDO(
+				TRIGGER_ID,
+				TRIGGER_KATEGORIE,
+				TRIGGER_ALTSYSTEMID,
+				TRIGGER_OPERATION,
+				TRIGGER_STATUS_IN_PROGRESS,
 				TRIGGER_NACHRICHT,
 				TRIGGER_CREATEDATUTCO,
 				TRIGGER_RUNATUTCO
@@ -122,6 +169,186 @@ public class TriggerServiceTest {
 
 		// verify invocations
 		verify(triggerComponent, times(1)).findAllLimited();
+	}
+	@Test
+	public void testFindAllErrors() {
+		// prepare test data
+		final TriggerDO expectedDO = getErrorTriggerDO();
+		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
+
+		// configure mocks
+		when(triggerComponent.findAllErrors("0","500")).thenReturn(expectedDOList);
+
+		// call test method
+		final List<TriggerDTO> actual = triggerServiceTest.findAllErrors("0","500");
+
+		// assert result
+		Java6Assertions.assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		Java6Assertions.assertThat(actual.get(0)).isNotNull();
+
+		Java6Assertions.assertThat(actual.get(0).getId())
+				.isEqualTo(expectedDO.getId());
+		Java6Assertions.assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedDO.getKategorie());
+		Java6Assertions.assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedDO.getAltsystemId());
+		Java6Assertions.assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedDO.getNachricht());
+		Java6Assertions.assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedDO.getCreatedAtUtc());
+		Java6Assertions.assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedDO.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerComponent, times(1)).findAllErrors("0","500");
+	}
+	@Test
+	public void testFindAllNews() {
+		// prepare test data
+		final TriggerDO expectedDO = getNewTriggerDO();
+		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
+
+		// configure mocks
+		when(triggerComponent.findAllNews("0","500")).thenReturn(expectedDOList);
+
+		// call test method
+		final List<TriggerDTO> actual = triggerServiceTest.findAllNews("0","500");
+
+		// assert result
+		Java6Assertions.assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		Java6Assertions.assertThat(actual.get(0)).isNotNull();
+
+		Java6Assertions.assertThat(actual.get(0).getId())
+				.isEqualTo(expectedDO.getId());
+		Java6Assertions.assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedDO.getKategorie());
+		Java6Assertions.assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedDO.getAltsystemId());
+		Java6Assertions.assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedDO.getNachricht());
+		Java6Assertions.assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedDO.getCreatedAtUtc());
+		Java6Assertions.assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedDO.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerComponent, times(1)).findAllNews("0","500");
+	}
+	@Test
+	public void testFindAllInProgress() {
+		// prepare test data
+		final TriggerDO expectedDO = getInProgressTriggerDO();
+		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
+
+		// configure mocks
+		when(triggerComponent.findAllInProgress("0","500")).thenReturn(expectedDOList);
+
+		// call test method
+		final List<TriggerDTO> actual = triggerServiceTest.findAllInProgress("0","500");
+
+		// assert result
+		Java6Assertions.assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		Java6Assertions.assertThat(actual.get(0)).isNotNull();
+
+		Java6Assertions.assertThat(actual.get(0).getId())
+				.isEqualTo(expectedDO.getId());
+		Java6Assertions.assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedDO.getKategorie());
+		Java6Assertions.assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedDO.getAltsystemId());
+		Java6Assertions.assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedDO.getNachricht());
+		Java6Assertions.assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedDO.getCreatedAtUtc());
+		Java6Assertions.assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedDO.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerComponent, times(1)).findAllInProgress("0","500");
+	}
+	@Test
+	public void testFindAllSuccess() {
+		// prepare test data
+		final TriggerDO expectedDO = getSuccsessTriggerDO();
+		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
+
+		// configure mocks
+		when(triggerComponent.findAllSuccessed("0","500")).thenReturn(expectedDOList);
+
+		// call test method
+		final List<TriggerDTO> actual = triggerServiceTest.findAllSuccessed("0","500");
+
+		// assert result
+		Java6Assertions.assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		Java6Assertions.assertThat(actual.get(0)).isNotNull();
+
+		Java6Assertions.assertThat(actual.get(0).getId())
+				.isEqualTo(expectedDO.getId());
+		Java6Assertions.assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedDO.getKategorie());
+		Java6Assertions.assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedDO.getAltsystemId());
+		Java6Assertions.assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedDO.getNachricht());
+		Java6Assertions.assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedDO.getCreatedAtUtc());
+		Java6Assertions.assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedDO.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerComponent, times(1)).findAllSuccessed("0","500");
+	}
+	@Test
+	public void testFindAllWithPages() {
+		// prepare test data
+		final TriggerDO expectedDO = getTriggerDO();
+		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
+
+		// configure mocks
+		when(triggerComponent.findAllWithPages("0","500")).thenReturn(expectedDOList);
+
+		// call test method
+		final List<TriggerDTO> actual = triggerServiceTest.findAllWithPages("0","500");
+
+		// assert result
+		Java6Assertions.assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		Java6Assertions.assertThat(actual.get(0)).isNotNull();
+
+		Java6Assertions.assertThat(actual.get(0).getId())
+				.isEqualTo(expectedDO.getId());
+		Java6Assertions.assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedDO.getKategorie());
+		Java6Assertions.assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedDO.getAltsystemId());
+		Java6Assertions.assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedDO.getNachricht());
+		Java6Assertions.assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedDO.getCreatedAtUtc());
+		Java6Assertions.assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedDO.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerComponent, times(1)).findAllWithPages("0","500");
 	}
 
 	@Test

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -14,6 +14,10 @@ public interface TriggerComponent extends ComponentFacade{
      */
     List<TriggerDO> findAll();
     List<TriggerDO> findAllLimited();
+    List<TriggerDO> findAllSuccessed();
+    List<TriggerDO> findAllErrors();
+    List<TriggerDO> findAllNews();
+    List<TriggerDO> findAllInProgress();
 
     List<TriggerDO> findAllUnprocessed();
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -13,6 +13,7 @@ public interface TriggerComponent extends ComponentFacade{
      * @return list of all Trigger classes in the DB
      */
     List<TriggerDO> findAll();
+    List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit);
     List<TriggerDO> findAllLimited();
     List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit);
     List<TriggerDO> findAllErrors(String multiplicator,String pageLimit);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -14,10 +14,10 @@ public interface TriggerComponent extends ComponentFacade{
      */
     List<TriggerDO> findAll();
     List<TriggerDO> findAllLimited();
-    List<TriggerDO> findAllSuccessed();
-    List<TriggerDO> findAllErrors();
-    List<TriggerDO> findAllNews();
-    List<TriggerDO> findAllInProgress();
+    List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit);
+    List<TriggerDO> findAllErrors(String multiplicator,String pageLimit);
+    List<TriggerDO> findAllNews(String multiplicator,String pageLimit);
+    List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit);
 
     List<TriggerDO> findAllUnprocessed();
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -39,23 +39,23 @@ public class TriggerComponentImpl implements TriggerComponent {
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllSuccessed() {
-        final List<TriggerBE> triggerBEList = triggerDAO.findSuccessed();
+    public List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findSuccessed(multiplicator,pageLimit);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllErrors() {
-        final List<TriggerBE> triggerBEList = triggerDAO.findErrors();
+    public List<TriggerDO> findAllErrors(String multiplicator,String pageLimit) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findErrors(multiplicator,pageLimit);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllInProgress() {
-        final List<TriggerBE> triggerBEList = triggerDAO.findInProgress();
+    public List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findInProgress(multiplicator,pageLimit);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllNews() {
-        final List<TriggerBE> triggerBEList = triggerDAO.findNews();
+    public List<TriggerDO> findAllNews(String multiplicator,String pageLimit) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findNews(multiplicator,pageLimit);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -31,8 +31,11 @@ public class TriggerComponentImpl implements TriggerComponent {
         final List<TriggerBE> triggerBEList = triggerDAO.findAll();
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
-
-
+    @Override
+    public List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findAllWithPages(multiplicator,pageLimit);
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
     @Override
     public List<TriggerDO> findAllLimited() {
         final List<TriggerBE> triggerBEList = triggerDAO.findAllLimited();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -38,8 +38,26 @@ public class TriggerComponentImpl implements TriggerComponent {
         final List<TriggerBE> triggerBEList = triggerDAO.findAllLimited();
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
-
-
+    @Override
+    public List<TriggerDO> findAllSuccessed() {
+        final List<TriggerBE> triggerBEList = triggerDAO.findSuccessed();
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
+    @Override
+    public List<TriggerDO> findAllErrors() {
+        final List<TriggerBE> triggerBEList = triggerDAO.findErrors();
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
+    @Override
+    public List<TriggerDO> findAllInProgress() {
+        final List<TriggerBE> triggerBEList = triggerDAO.findInProgress();
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
+    @Override
+    public List<TriggerDO> findAllNews() {
+        final List<TriggerBE> triggerBEList = triggerDAO.findNews();
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
     @Override
     public List<TriggerDO> findAllUnprocessed() {
         final List<TriggerBE> triggerBEList = triggerDAO.findAllUnprocessed();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -99,7 +99,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_operation op"
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 4"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
@@ -109,7 +109,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_operation op"
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 1"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
@@ -119,20 +119,21 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_operation op"
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 2"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
+
     private static final String FIND_ALL_ERRORS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status"
-                    + "         where status = 3"
-                    + " ORDER BY aenderung_id"
-                    + " LIMIT 500";
+            "SELECT * " +
+                    " FROM altsystem_aenderung" +
+                    "     LEFT JOIN altsystem_aenderung_operation op" +
+                    "         ON altsystem_aenderung.operation = op.operation_id" +
+                    "     LEFT JOIN altsystem_aenderung_status st" +
+                    "         ON altsystem_aenderung.status = st.status_id" +
+                    "         where status = 3" +
+                    " ORDER BY aenderung_id" +
+                    " LIMIT 500";
 
 
     private final BasicDAO basicDAO;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -93,6 +93,15 @@ public class TriggerDAO implements DataAccessObject {
                     + "         where status != 4"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
+    private static final String FIND_ALL_WITH_PAGES =
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status_id"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_SUCCESSED =
             "SELECT * "
                     + " FROM altsystem_aenderung"
@@ -185,6 +194,11 @@ public class TriggerDAO implements DataAccessObject {
 
     public List<TriggerBE> findAll() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
+    }
+    public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit) {
+        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit) {
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -102,7 +102,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 4"
                     + " ORDER BY aenderung_id"
-                    + " LIMIT 500";
+                    + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_NEWS =
             "SELECT * "
                     + " FROM altsystem_aenderung"
@@ -112,7 +112,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 1"
                     + " ORDER BY aenderung_id"
-                    + " LIMIT 500";
+                    + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_IN_PROGRESS =
             "SELECT * "
                     + " FROM altsystem_aenderung"
@@ -122,18 +122,18 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 2"
                     + " ORDER BY aenderung_id"
-                    + " LIMIT 500";
+                    + " LIMIT $limit$ OFFSET $offset$";
 
     private static final String FIND_ALL_ERRORS =
-            "SELECT * " +
-                    " FROM altsystem_aenderung" +
-                    "     LEFT JOIN altsystem_aenderung_operation op" +
-                    "         ON altsystem_aenderung.operation = op.operation_id" +
-                    "     LEFT JOIN altsystem_aenderung_status st" +
-                    "         ON altsystem_aenderung.status = st.status_id" +
-                    "         where status = 3" +
-                    " ORDER BY aenderung_id" +
-                    " LIMIT 500";
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status_id"
+                    + "         where status = 3"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT $limit$ OFFSET $offset$";
 
 
     private final BasicDAO basicDAO;
@@ -186,17 +186,25 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAll() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
-    public List<TriggerBE> findSuccessed() {
-        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_SUCCESSED);
+    public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit) {
+        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findNews() {
-        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_NEWS);
+    public List<TriggerBE> findNews(String multiplicator,String pageLimit) {
+        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findErrors() {
-        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_ERRORS);
+    public List<TriggerBE> findErrors(String multiplicator,String pageLimit) {
+        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findInProgress() {
-        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_IN_PROGRESS);
+    public List<TriggerBE> findInProgress(String multiplicator,String pageLimit) {
+        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findAllUnprocessed() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_UNPROCESSED);
@@ -204,6 +212,7 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAllLimited() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_LIMITED);
     }
+
 
     public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
         basicDAO.setCreationAttributes(triggerBE, currentUserId);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -93,6 +93,47 @@ public class TriggerDAO implements DataAccessObject {
                     + "         where status != 4"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
+    private static final String FIND_ALL_SUCCESSED =
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         where status = 4"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT 500";
+    private static final String FIND_ALL_NEWS =
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         where status = 1"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT 500";
+    private static final String FIND_ALL_IN_PROGRESS =
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         where status = 2"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT 500";
+    private static final String FIND_ALL_ERRORS =
+            "SELECT * "
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status"
+                    + "         where status = 3"
+                    + " ORDER BY aenderung_id"
+                    + " LIMIT 500";
+
 
     private final BasicDAO basicDAO;
 
@@ -144,7 +185,18 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAll() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
-
+    public List<TriggerBE> findSuccessed() {
+        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_SUCCESSED);
+    }
+    public List<TriggerBE> findNews() {
+        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_NEWS);
+    }
+    public List<TriggerBE> findErrors() {
+        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_ERRORS);
+    }
+    public List<TriggerBE> findInProgress() {
+        return basicDAO.selectEntityList(TRIGGER, FIND_ALL_IN_PROGRESS);
+    }
     public List<TriggerBE> findAllUnprocessed() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_UNPROCESSED);
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -90,6 +90,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         AND st.status_name != 'SUCCESS'"
+                    + "         where status != 4"
                     + " ORDER BY aenderung_id"
                     + " LIMIT 500";
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.trigger.api.types.TriggerChangeOperation;
 import de.bogenliga.application.business.trigger.api.types.TriggerChangeStatus;
 import de.bogenliga.application.business.trigger.api.types.TriggerDO;
-import de.bogenliga.application.business.trigger.impl.dao.MigrationTimestampDAO;
 import de.bogenliga.application.business.trigger.impl.dao.TriggerDAO;
 import de.bogenliga.application.business.trigger.impl.entity.MigrationTimestampBE;
 import de.bogenliga.application.business.trigger.impl.entity.TriggerBE;
@@ -32,6 +31,10 @@ public class TriggerComponentImplTest {
 	private static final Long TRIGGER_ALTSYSTEMID = 234L;
 	private static final TriggerChangeOperation TRIGGER_OPERATION = null;
 	private static final TriggerChangeStatus TRIGGER_STATUS = null;
+	private static final TriggerChangeStatus TRIGGER_STATUS_ERROR = TriggerChangeStatus.ERROR;
+	private static final TriggerChangeStatus TRIGGER_STATUS_NEW = TriggerChangeStatus.NEW;
+	private static final TriggerChangeStatus TRIGGER_STATUS_SUCCSESS = TriggerChangeStatus.SUCCESS;
+	private static final TriggerChangeStatus TRIGGER_STATUS_IN_PROGRESS = TriggerChangeStatus.IN_PROGRESS;
 	private static final String TRIGGER_NACHRICHT = "testmsg";
 	private static final Timestamp TRIGGER_RUNATUTC = null;
 	private static final Timestamp TRIGGER_SYNCTIMESTAMP = null;
@@ -68,6 +71,54 @@ public class TriggerComponentImplTest {
 
 	public static final OffsetDateTime TRIGGER_CREATEDATUTCO = null;
 	public static final OffsetDateTime TRIGGER_RUNATUTCO = null;
+	public static TriggerBE getErrorTriggerBE() {
+		final TriggerBE expectedBE = new TriggerBE();
+		expectedBE.setId(TRIGGER_ID);
+		expectedBE.setKategorie(TRIGGER_KATEGORIE);
+		expectedBE.setAltsystemId(TRIGGER_ALTSYSTEMID);
+		expectedBE.setChangeOperation(TRIGGER_OPERATION);
+		expectedBE.setChangeStatus(TRIGGER_STATUS_ERROR);
+		expectedBE.setNachricht(TRIGGER_NACHRICHT);
+		expectedBE.setRunAtUtc(TRIGGER_RUNATUTC);
+
+		return expectedBE;
+	}
+	public static TriggerBE getNewTriggerBE() {
+		final TriggerBE expectedBE = new TriggerBE();
+		expectedBE.setId(TRIGGER_ID);
+		expectedBE.setKategorie(TRIGGER_KATEGORIE);
+		expectedBE.setAltsystemId(TRIGGER_ALTSYSTEMID);
+		expectedBE.setChangeOperation(TRIGGER_OPERATION);
+		expectedBE.setChangeStatus(TRIGGER_STATUS_NEW);
+		expectedBE.setNachricht(TRIGGER_NACHRICHT);
+		expectedBE.setRunAtUtc(TRIGGER_RUNATUTC);
+
+		return expectedBE;
+	}
+	public static TriggerBE getSuccessTriggerBE() {
+		final TriggerBE expectedBE = new TriggerBE();
+		expectedBE.setId(TRIGGER_ID);
+		expectedBE.setKategorie(TRIGGER_KATEGORIE);
+		expectedBE.setAltsystemId(TRIGGER_ALTSYSTEMID);
+		expectedBE.setChangeOperation(TRIGGER_OPERATION);
+		expectedBE.setChangeStatus(TRIGGER_STATUS_SUCCSESS);
+		expectedBE.setNachricht(TRIGGER_NACHRICHT);
+		expectedBE.setRunAtUtc(TRIGGER_RUNATUTC);
+
+		return expectedBE;
+	}
+	public static TriggerBE getInProgressTriggerBE() {
+		final TriggerBE expectedBE = new TriggerBE();
+		expectedBE.setId(TRIGGER_ID);
+		expectedBE.setKategorie(TRIGGER_KATEGORIE);
+		expectedBE.setAltsystemId(TRIGGER_ALTSYSTEMID);
+		expectedBE.setChangeOperation(TRIGGER_OPERATION);
+		expectedBE.setChangeStatus(TRIGGER_STATUS_IN_PROGRESS);
+		expectedBE.setNachricht(TRIGGER_NACHRICHT);
+		expectedBE.setRunAtUtc(TRIGGER_RUNATUTC);
+
+		return expectedBE;
+	}
 	public static TriggerDO getTriggerDO() {
 		return new TriggerDO(
 				TRIGGER_ID,
@@ -80,7 +131,6 @@ public class TriggerComponentImplTest {
 				TRIGGER_RUNATUTCO
 		);
 	}
-
 	@Test
 	public void findAll() {
 		// prepare test data
@@ -201,7 +251,204 @@ public class TriggerComponentImplTest {
 		// verify invocations
 		verify(triggerDAO, times(1)).findAllUnprocessed();
 	}
+	@Test
+	public void findAllErrors() {
+		// prepare test data
+		final TriggerBE expectedBE = getTriggerBE();
+		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
+		// configure mocks
+		when(triggerDAO.findErrors("0","500")).thenReturn(expectedBEList);
 
+		// call test method
+		final List<TriggerDO> actual = underTest.findAllErrors("0","500");
 
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+
+		assertThat(actual.get(0).getId())
+				.isEqualTo(expectedBE.getId());
+		assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedBE.getKategorie());
+		assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedBE.getAltsystemId());
+		assertThat(actual.get(0).getOperation())
+				.isEqualTo(expectedBE.getChangeOperation());
+		assertThat(actual.get(0).getStatus())
+				.isEqualTo(expectedBE.getChangeStatus());
+		assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedBE.getNachricht());
+		assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedBE.getCreatedAtUtc());
+		assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedBE.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerDAO, times(1)).findErrors("0","500");
+	}
+	@Test
+	public void findAllNews() {
+		// prepare test data
+		final TriggerBE expectedBE = getNewTriggerBE();
+		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
+
+		// configure mocks
+		when(triggerDAO.findNews("0","500")).thenReturn(expectedBEList);
+
+		// call test method
+		final List<TriggerDO> actual = underTest.findAllNews("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+
+		assertThat(actual.get(0).getId())
+				.isEqualTo(expectedBE.getId());
+		assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedBE.getKategorie());
+		assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedBE.getAltsystemId());
+		assertThat(actual.get(0).getOperation())
+				.isEqualTo(expectedBE.getChangeOperation());
+		assertThat(actual.get(0).getStatus())
+				.isEqualTo(expectedBE.getChangeStatus());
+		assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedBE.getNachricht());
+		assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedBE.getCreatedAtUtc());
+		assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedBE.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerDAO, times(1)).findNews("0","500");
+	}
+	@Test
+	public void findAllSuccess() {
+		// prepare test data
+		final TriggerBE expectedBE = getSuccessTriggerBE();
+		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
+
+		// configure mocks
+		when(triggerDAO.findSuccessed("0","500")).thenReturn(expectedBEList);
+
+		// call test method
+		final List<TriggerDO> actual = underTest.findAllSuccessed("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+
+		assertThat(actual.get(0).getId())
+				.isEqualTo(expectedBE.getId());
+		assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedBE.getKategorie());
+		assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedBE.getAltsystemId());
+		assertThat(actual.get(0).getOperation())
+				.isEqualTo(expectedBE.getChangeOperation());
+		assertThat(actual.get(0).getStatus())
+				.isEqualTo(expectedBE.getChangeStatus());
+		assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedBE.getNachricht());
+		assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedBE.getCreatedAtUtc());
+		assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedBE.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerDAO, times(1)).findSuccessed("0","500");
+	}
+	@Test
+	public void findAllInProgress() {
+		// prepare test data
+		final TriggerBE expectedBE = getInProgressTriggerBE();
+		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
+
+		// configure mocks
+		when(triggerDAO.findInProgress("0","500")).thenReturn(expectedBEList);
+
+		// call test method
+		final List<TriggerDO> actual = underTest.findAllInProgress("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+
+		assertThat(actual.get(0).getId())
+				.isEqualTo(expectedBE.getId());
+		assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedBE.getKategorie());
+		assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedBE.getAltsystemId());
+		assertThat(actual.get(0).getOperation())
+				.isEqualTo(expectedBE.getChangeOperation());
+		assertThat(actual.get(0).getStatus())
+				.isEqualTo(expectedBE.getChangeStatus());
+		assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedBE.getNachricht());
+		assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedBE.getCreatedAtUtc());
+		assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedBE.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerDAO, times(1)).findInProgress("0","500");
+	}
+	@Test
+	public void findAllWithPages() {
+		// prepare test data
+		final TriggerBE expectedBE = getErrorTriggerBE();
+		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
+
+		// configure mocks
+		when(triggerDAO.findAllWithPages("0","500")).thenReturn(expectedBEList);
+
+		// call test method
+		final List<TriggerDO> actual = underTest.findAllWithPages("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+
+		assertThat(actual.get(0).getId())
+				.isEqualTo(expectedBE.getId());
+		assertThat(actual.get(0).getKategorie())
+				.isEqualTo(expectedBE.getKategorie());
+		assertThat(actual.get(0).getAltsystemId())
+				.isEqualTo(expectedBE.getAltsystemId());
+		assertThat(actual.get(0).getOperation())
+				.isEqualTo(expectedBE.getChangeOperation());
+		assertThat(actual.get(0).getStatus())
+				.isEqualTo(expectedBE.getChangeStatus());
+		assertThat(actual.get(0).getNachricht())
+				.isEqualTo(expectedBE.getNachricht());
+		assertThat(actual.get(0).getCreatedAtUtc())
+				.isEqualTo(expectedBE.getCreatedAtUtc());
+		assertThat(actual.get(0).getRunAtUtc())
+				.isEqualTo(expectedBE.getRunAtUtc());
+
+		// verify invocations
+		verify(triggerDAO, times(1)).findAllWithPages("0","500");
+	}
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
@@ -68,7 +68,6 @@ public class TriggerComponentImplTest {
 		return expectedBE;
 	}
 
-
 	public static final OffsetDateTime TRIGGER_CREATEDATUTCO = null;
 	public static final OffsetDateTime TRIGGER_RUNATUTCO = null;
 	public static TriggerBE getErrorTriggerBE() {

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
@@ -16,6 +16,10 @@ import de.bogenliga.application.business.trigger.impl.entity.RawTriggerBE;
 import de.bogenliga.application.business.trigger.impl.entity.TriggerBE;
 import de.bogenliga.application.business.trigger.impl.mapper.TriggerMapper;
 import de.bogenliga.application.common.component.dao.BasicDAO;
+import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getErrorTriggerBE;
+import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getInProgressTriggerBE;
+import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getNewTriggerBE;
+import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getSuccessTriggerBE;
 import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getTriggerBE;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -138,5 +142,99 @@ public class TriggerDAOTest {
 
 		assertThat(actual.get(0)).isNotNull();
 	}
+	@Test
+	public void testFindAllErrors() {
+		// prepare test data
+		final TriggerBE expectedBE = getErrorTriggerBE();
 
+		// configure mocks
+		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+		// call test method
+		final List<TriggerBE> actual = triggerDAO.findErrors("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+	}
+	@Test
+	public void testFindAllNews() {
+		// prepare test data
+		final TriggerBE expectedBE = getNewTriggerBE();
+
+		// configure mocks
+		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+		// call test method
+		final List<TriggerBE> actual = triggerDAO.findNews("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+	}
+	@Test
+	public void testFindAllSuccess() {
+		// prepare test data
+		final TriggerBE expectedBE = getSuccessTriggerBE();
+
+		// configure mocks
+		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+		// call test method
+		final List<TriggerBE> actual = triggerDAO.findSuccessed("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+	}
+	@Test
+	public void testFindAllInProgress() {
+		// prepare test data
+		final TriggerBE expectedBE = getInProgressTriggerBE();
+
+		// configure mocks
+		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+		// call test method
+		final List<TriggerBE> actual = triggerDAO.findInProgress("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+	}
+	@Test
+	public void testFindAllWithPages() {
+		// prepare test data
+		final TriggerBE expectedBE = getTriggerBE();
+
+		// configure mocks
+		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+		// call test method
+		final List<TriggerBE> actual = triggerDAO.findAllWithPages("0","500");
+
+		// assert result
+		assertThat(actual)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		assertThat(actual.get(0)).isNotNull();
+	}
 }


### PR DESCRIPTION
Pull-Anfrage für Ticket 1547 - Frontend-Änderungen:

Hinzugefügter Filter:
Implementierung eines Filters zur Sortierung nach dem Statusfeld mit dem Standardwert "Error".
Paging für Migrationsübersicht:
Integration einer Funktion zur Blätterung durch die Ergebnisse in der Migrationsübersicht, um alle Daten anzuzeigen.
Sicherheitsabfrage für Migrationsstart:
Implementierung einer Sicherheitsabfrage vor dem Start der Migration, um den Benutzer zu fragen, ob er die Aktion wirklich ausführen möchte. 