### PR TITLE
#1591 löschen vom protokoll der datenmigration epic api entpunkt

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -179,12 +180,11 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
-    @GetMapping("/deleteEntries")
+    @DeleteMapping("/deleteEntries")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
     public List<TriggerDTO> deleteEntries(@RequestParam("status") String status,@RequestParam("dateInterval") String dateInterval) {
         //TODO
         final List<TriggerDO> triggerDOList = triggerComponent.deleteEntries(status,dateInterval);
-
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     public void setMigrationTimestamp(Timestamp timestamp){

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -182,10 +182,8 @@ public class TriggerService implements ServiceFacade {
     }
     @DeleteMapping("/deleteEntries")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> deleteEntries(@RequestParam("status") String status,@RequestParam("dateInterval") String dateInterval) {
-        //TODO
-        final List<TriggerDO> triggerDOList = triggerComponent.deleteEntries(status,dateInterval);
-        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    public void deleteEntries(@RequestParam("status") String status,@RequestParam("dateInterval") String dateInterval) {
+        triggerComponent.deleteEntries(status,dateInterval);
     }
     public void setMigrationTimestamp(Timestamp timestamp){
         List<MigrationTimestampBE> timestamplist = migrationTimestampDAO.findAll();

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -136,13 +136,6 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
-    @GetMapping("/findAllWithPages")
-    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllWithPages(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllWithPages(offsetMultiplicator, queryPageLimit);
-
-        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
-    }
     @GetMapping("/findAllUnprocessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
     public List<TriggerDTO> findAllUnprocessed() {
@@ -150,31 +143,39 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
+
+    @GetMapping("/findAllWithPages")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> findAllWithPages(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllWithPages(offsetMultiplicator, queryPageLimit,dateInterval);
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
     @GetMapping("/findSuccessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllSuccessed(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed(offsetMultiplicator, queryPageLimit);
+    public List<TriggerDTO> findAllSuccessed(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed(offsetMultiplicator, queryPageLimit,dateInterval);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findErrors")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllErrors(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllErrors(offsetMultiplicator, queryPageLimit);
+    public List<TriggerDTO> findAllErrors(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllErrors(offsetMultiplicator, queryPageLimit,dateInterval);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findInProgress")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllInProgress(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllInProgress(offsetMultiplicator, queryPageLimit);
+    public List<TriggerDTO> findAllInProgress(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllInProgress(offsetMultiplicator, queryPageLimit,dateInterval);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findNews")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> findAllNews(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews(offsetMultiplicator, queryPageLimit);
+    public List<TriggerDTO> findAllNews(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews(offsetMultiplicator, queryPageLimit,dateInterval);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -180,9 +180,9 @@ public class TriggerService implements ServiceFacade {
     }
     @GetMapping("/deleteEntries")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
-    public List<TriggerDTO> deleteEntries(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+    public List<TriggerDTO> deleteEntries(@RequestParam("status") String status,@RequestParam("dateInterval") String dateInterval) {
         //TODO
-        final List<TriggerDO> triggerDOList = triggerComponent.deleteAllSuccessedOneMonthAgo();
+        final List<TriggerDO> triggerDOList = triggerComponent.deleteEntries(status,dateInterval);
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -182,7 +182,7 @@ public class TriggerService implements ServiceFacade {
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
     public List<TriggerDTO> deleteEntries(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
         //TODO
-        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews(offsetMultiplicator, queryPageLimit);
+        final List<TriggerDO> triggerDOList = triggerComponent.deleteAllSuccessedOneMonthAgo();
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -178,6 +178,14 @@ public class TriggerService implements ServiceFacade {
 
         return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
+    @GetMapping("/deleteEntries")
+    @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
+    public List<TriggerDTO> deleteEntries(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit) {
+        //TODO
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllNews(offsetMultiplicator, queryPageLimit);
+
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
+    }
     public void setMigrationTimestamp(Timestamp timestamp){
         List<MigrationTimestampBE> timestamplist = migrationTimestampDAO.findAll();
         if (timestamplist.isEmpty()){

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
@@ -350,6 +350,47 @@ public class TriggerServiceTest {
 		// verify invocations
 		verify(triggerComponent, times(1)).findAllWithPages("0","500", "1 MONTH");
 	}
+	@Test
+	public void testDeleteNewEntries() {
+		// Call the method
+		triggerComponent.deleteEntries("Neu", "1 MONTH");
+
+		// Verify that triggerComponent.deleteEntries was called with the correct parameters
+		verify(triggerComponent).deleteEntries("Neu", "1 MONTH");
+	}
+	@Test
+	public void testDeleteErrorEntries() {
+		// Call the method
+		triggerComponent.deleteEntries("Fehlgeschlagen", "1 MONTH");
+
+		// Verify that triggerComponent.deleteEntries was called with the correct parameters
+		verify(triggerComponent).deleteEntries("Fehlgeschlagen", "1 MONTH");
+	}
+	@Test
+	public void testDeleteInProgressEntries() {
+		// Call the method
+		triggerComponent.deleteEntries("Laufend", "1 MONTH");
+
+		// Verify that triggerComponent.deleteEntries was called with the correct parameters
+		verify(triggerComponent).deleteEntries("Laufend", "1 MONTH");
+	}
+	@Test
+	public void testDeleteSuccessEntries() {
+		// Call the method
+		triggerComponent.deleteEntries("Erfolgreich", "1 MONTH");
+
+		// Verify that triggerComponent.deleteEntries was called with the correct parameters
+		verify(triggerComponent).deleteEntries("Erfolgreich", "1 MONTH");
+	}
+	@Test
+	public void testDeleteAllEntries() {
+		// Call the method
+		triggerComponent.deleteEntries("Alle", "1 MONTH");
+
+		// Verify that triggerComponent.deleteEntries was called with the correct parameters
+		verify(triggerComponent).deleteEntries("Alle", "1 MONTH");
+	}
+
 
 	@Test
 	public void testLoadUnprocessedChanges() {

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
@@ -177,10 +177,10 @@ public class TriggerServiceTest {
 		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
 
 		// configure mocks
-		when(triggerComponent.findAllErrors("0","500")).thenReturn(expectedDOList);
+		when(triggerComponent.findAllErrors("0","500", "1 MONTH")).thenReturn(expectedDOList);
 
 		// call test method
-		final List<TriggerDTO> actual = triggerServiceTest.findAllErrors("0","500");
+		final List<TriggerDTO> actual = triggerServiceTest.findAllErrors("0","500", "1 MONTH");
 
 		// assert result
 		Java6Assertions.assertThat(actual)
@@ -204,7 +204,7 @@ public class TriggerServiceTest {
 				.isEqualTo(expectedDO.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerComponent, times(1)).findAllErrors("0","500");
+		verify(triggerComponent, times(1)).findAllErrors("0","500", "1 MONTH");
 	}
 	@Test
 	public void testFindAllNews() {
@@ -213,10 +213,10 @@ public class TriggerServiceTest {
 		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
 
 		// configure mocks
-		when(triggerComponent.findAllNews("0","500")).thenReturn(expectedDOList);
+		when(triggerComponent.findAllNews("0","500", "1 MONTH")).thenReturn(expectedDOList);
 
 		// call test method
-		final List<TriggerDTO> actual = triggerServiceTest.findAllNews("0","500");
+		final List<TriggerDTO> actual = triggerServiceTest.findAllNews("0","500", "1 MONTH");
 
 		// assert result
 		Java6Assertions.assertThat(actual)
@@ -240,7 +240,7 @@ public class TriggerServiceTest {
 				.isEqualTo(expectedDO.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerComponent, times(1)).findAllNews("0","500");
+		verify(triggerComponent, times(1)).findAllNews("0","500", "1 MONTH");
 	}
 	@Test
 	public void testFindAllInProgress() {
@@ -249,10 +249,10 @@ public class TriggerServiceTest {
 		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
 
 		// configure mocks
-		when(triggerComponent.findAllInProgress("0","500")).thenReturn(expectedDOList);
+		when(triggerComponent.findAllInProgress("0","500", "1 MONTH")).thenReturn(expectedDOList);
 
 		// call test method
-		final List<TriggerDTO> actual = triggerServiceTest.findAllInProgress("0","500");
+		final List<TriggerDTO> actual = triggerServiceTest.findAllInProgress("0","500", "1 MONTH");
 
 		// assert result
 		Java6Assertions.assertThat(actual)
@@ -276,7 +276,7 @@ public class TriggerServiceTest {
 				.isEqualTo(expectedDO.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerComponent, times(1)).findAllInProgress("0","500");
+		verify(triggerComponent, times(1)).findAllInProgress("0","500", "1 MONTH");
 	}
 	@Test
 	public void testFindAllSuccess() {
@@ -285,10 +285,10 @@ public class TriggerServiceTest {
 		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
 
 		// configure mocks
-		when(triggerComponent.findAllSuccessed("0","500")).thenReturn(expectedDOList);
+		when(triggerComponent.findAllSuccessed("0","500", "1 MONTH")).thenReturn(expectedDOList);
 
 		// call test method
-		final List<TriggerDTO> actual = triggerServiceTest.findAllSuccessed("0","500");
+		final List<TriggerDTO> actual = triggerServiceTest.findAllSuccessed("0","500", "1 MONTH");
 
 		// assert result
 		Java6Assertions.assertThat(actual)
@@ -312,7 +312,7 @@ public class TriggerServiceTest {
 				.isEqualTo(expectedDO.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerComponent, times(1)).findAllSuccessed("0","500");
+		verify(triggerComponent, times(1)).findAllSuccessed("0","500", "1 MONTH");
 	}
 	@Test
 	public void testFindAllWithPages() {
@@ -321,10 +321,10 @@ public class TriggerServiceTest {
 		final List<TriggerDO> expectedDOList = Collections.singletonList(expectedDO);
 
 		// configure mocks
-		when(triggerComponent.findAllWithPages("0","500")).thenReturn(expectedDOList);
+		when(triggerComponent.findAllWithPages("0","500", "1 MONTH")).thenReturn(expectedDOList);
 
 		// call test method
-		final List<TriggerDTO> actual = triggerServiceTest.findAllWithPages("0","500");
+		final List<TriggerDTO> actual = triggerServiceTest.findAllWithPages("0","500", "1 MONTH");
 
 		// assert result
 		Java6Assertions.assertThat(actual)
@@ -348,7 +348,7 @@ public class TriggerServiceTest {
 				.isEqualTo(expectedDO.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerComponent, times(1)).findAllWithPages("0","500");
+		verify(triggerComponent, times(1)).findAllWithPages("0","500", "1 MONTH");
 	}
 
 	@Test

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -20,7 +20,7 @@ public interface TriggerComponent extends ComponentFacade{
     List<TriggerDO> findAllNews(String multiplicator,String pageLimit,String dateInterval);
     List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit,String dateInterval);
 
-    List<TriggerDO> deleteEntries(String status, String dateInterval);
+    void deleteEntries(String status, String dateInterval);
 
     List<TriggerDO> findAllUnprocessed();
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -20,6 +20,8 @@ public interface TriggerComponent extends ComponentFacade{
     List<TriggerDO> findAllNews(String multiplicator,String pageLimit);
     List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit);
 
+    List<TriggerDO> deleteAllSuccessedOneMonthAgo();
+
     List<TriggerDO> findAllUnprocessed();
 
     TriggerDO create(TriggerDO triggerDO, Long currentUserId);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/api/TriggerComponent.java
@@ -13,14 +13,14 @@ public interface TriggerComponent extends ComponentFacade{
      * @return list of all Trigger classes in the DB
      */
     List<TriggerDO> findAll();
-    List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit);
+    List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit,String dateInterval);
     List<TriggerDO> findAllLimited();
-    List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit);
-    List<TriggerDO> findAllErrors(String multiplicator,String pageLimit);
-    List<TriggerDO> findAllNews(String multiplicator,String pageLimit);
-    List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit);
+    List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit,String dateInterval);
+    List<TriggerDO> findAllErrors(String multiplicator,String pageLimit,String dateInterval);
+    List<TriggerDO> findAllNews(String multiplicator,String pageLimit,String dateInterval);
+    List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit,String dateInterval);
 
-    List<TriggerDO> deleteAllSuccessedOneMonthAgo();
+    List<TriggerDO> deleteEntries(String status, String dateInterval);
 
     List<TriggerDO> findAllUnprocessed();
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -60,9 +60,8 @@ public class TriggerComponentImpl implements TriggerComponent {
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> deleteEntries(String status, String dateInterval) {
-        final List<TriggerBE> triggerBEList = triggerDAO.deleteEntries(status,dateInterval);
-        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    public void deleteEntries(String status, String dateInterval) {
+        triggerDAO.deleteEntries(status,dateInterval);
     }
     @Override
     public List<TriggerDO> findAllUnprocessed() {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -30,38 +30,38 @@ public class TriggerComponentImpl implements TriggerComponent {
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit) {
-        final List<TriggerBE> triggerBEList = triggerDAO.findAllWithPages(multiplicator,pageLimit);
-        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
-    }
-    @Override
     public List<TriggerDO> findAllLimited() {
         final List<TriggerBE> triggerBEList = triggerDAO.findAllLimited();
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit) {
-        final List<TriggerBE> triggerBEList = triggerDAO.findSuccessed(multiplicator,pageLimit);
+    public List<TriggerDO> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findAllWithPages(multiplicator,pageLimit,dateInterval);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllErrors(String multiplicator,String pageLimit) {
-        final List<TriggerBE> triggerBEList = triggerDAO.findErrors(multiplicator,pageLimit);
+    public List<TriggerDO> findAllSuccessed(String multiplicator,String pageLimit,String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findSuccessed(multiplicator,pageLimit,dateInterval);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit) {
-        final List<TriggerBE> triggerBEList = triggerDAO.findInProgress(multiplicator,pageLimit);
+    public List<TriggerDO> findAllErrors(String multiplicator,String pageLimit,String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findErrors(multiplicator,pageLimit,dateInterval);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> findAllNews(String multiplicator,String pageLimit) {
-        final List<TriggerBE> triggerBEList = triggerDAO.findNews(multiplicator,pageLimit);
+    public List<TriggerDO> findAllInProgress(String multiplicator,String pageLimit,String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findInProgress(multiplicator,pageLimit,dateInterval);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override
-    public List<TriggerDO> deleteAllSuccessedOneMonthAgo() {
-        final List<TriggerBE> triggerBEList = triggerDAO.deleteSuccessedOneMonthAgo();
+    public List<TriggerDO> findAllNews(String multiplicator,String pageLimit,String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.findNews(multiplicator,pageLimit,dateInterval);
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
+    @Override
+    public List<TriggerDO> deleteEntries(String status, String dateInterval) {
+        final List<TriggerBE> triggerBEList = triggerDAO.deleteEntries(status,dateInterval);
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImpl.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import de.bogenliga.application.business.tabletsession.impl.entity.TabletSessionBE;
-import de.bogenliga.application.business.tabletsession.impl.mapper.TabletSessionMapper;
 import de.bogenliga.application.business.trigger.api.TriggerComponent;
 import de.bogenliga.application.business.trigger.api.types.TriggerDO;
 import de.bogenliga.application.business.trigger.impl.dao.TriggerDAO;
@@ -59,6 +57,11 @@ public class TriggerComponentImpl implements TriggerComponent {
     @Override
     public List<TriggerDO> findAllNews(String multiplicator,String pageLimit) {
         final List<TriggerBE> triggerBEList = triggerDAO.findNews(multiplicator,pageLimit);
+        return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
+    }
+    @Override
+    public List<TriggerDO> deleteAllSuccessedOneMonthAgo() {
+        final List<TriggerBE> triggerBEList = triggerDAO.deleteSuccessedOneMonthAgo();
         return triggerBEList.stream().map(TriggerMapper.toTriggerDO).collect(Collectors.toList());
     }
     @Override

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -230,7 +230,7 @@ public class TriggerDAO implements DataAccessObject {
         String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> deleteEntries(String status, String dateInterval) {
+    public void deleteEntries(String status, String dateInterval) {
         String actualStatus;
         switch (status){
             case("Neu"):
@@ -249,9 +249,8 @@ public class TriggerDAO implements DataAccessObject {
                 actualStatus = "LOL";
         }
         String actualDataInterval = dateInterval.replace("%20", " ");
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDataInterval);
-        return basicDAO.selectEntityList(TRIGGER,changedSQL);
+        basicDAO.executeQuery(changedSQL);
     }
 
     public List<TriggerBE> findAllUnprocessed() {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -155,6 +155,11 @@ public class TriggerDAO implements DataAccessObject {
                     "WHERE status = $status$ " +
                     "AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
                     "COMMIT;";
+    private static final String DELETE_ALL_ENTRIES =
+            "START TRANSACTION; " +
+                    "DELETE FROM altsystem_aenderung " +
+                    "WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
+                    "COMMIT;";
     private final BasicDAO basicDAO;
 
 
@@ -246,11 +251,18 @@ public class TriggerDAO implements DataAccessObject {
                 actualStatus = "4";
                 break;
             default:
-                actualStatus = "LOL";
+                actualStatus = "5";
         }
-        String actualDataInterval = dateInterval.replace("%20", " ");
-        String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDataInterval);
-        basicDAO.executeQuery(changedSQL);
+        if(actualStatus.equals("5")){
+            String actualDataInterval = dateInterval.replace("%20", " ");
+            String changedSQL = DELETE_ALL_ENTRIES.replace("$dateInterval$", actualDataInterval);
+            basicDAO.executeQuery(changedSQL);
+        }
+        else{
+            String actualDateInterval = dateInterval.replace("%20", " ");
+            String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDateInterval);
+            basicDAO.executeQuery(changedSQL);
+        }
     }
 
     public List<TriggerBE> findAllUnprocessed() {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -150,14 +150,11 @@ public class TriggerDAO implements DataAccessObject {
                     + " LIMIT $limit$ OFFSET $offset$";
 
     private static final String DELETE_ENTRIES =
-            "DELETE altsystem_aenderung, op, st"
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = $status$"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'";
+            "START TRANSACTION; " +
+                    "DELETE FROM altsystem_aenderung " +
+                    "WHERE status = $status$ " +
+                    "AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
+                    "COMMIT;";
     private final BasicDAO basicDAO;
 
 
@@ -209,39 +206,52 @@ public class TriggerDAO implements DataAccessObject {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
     public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
         String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
         String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
         String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
         String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
-        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
         String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> deleteEntries(String status, String dateInterval) {
+        String actualStatus;
+        switch (status){
+            case("Neu"):
+                actualStatus = "1";
+                break;
+            case("Laufend"):
+                actualStatus = "2";
+                break;
+            case("Fehlgeschlagen"):
+                actualStatus = "3";
+                break;
+            case("Erfolgreich"):
+                actualStatus = "4";
+                break;
+            default:
+                actualStatus = "LOL";
+        }
+        String actualDataInterval = dateInterval.replace("%20", " ");
         LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
-        String changedSQL = DELETE_ENTRIES.replace("$status$", status).replace("$dateInterval$", dateInterval);
-        return basicDAO.selectEntityList(TRIGGER,DELETE_ENTRIES);
+        String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDataInterval);
+        return basicDAO.selectEntityList(TRIGGER,changedSQL);
     }
 
     public List<TriggerBE> findAllUnprocessed() {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -100,6 +100,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
+                    + "         WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_SUCCESSED =
@@ -110,6 +111,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 4"
+                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_NEWS =
@@ -120,6 +122,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 1"
+                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_IN_PROGRESS =
@@ -130,6 +133,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 2"
+                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
 
@@ -141,20 +145,19 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 3"
+                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
 
-    private static final String DELETE_ALL_SUCCESSED_ONE_MONTH_AGO =
+    private static final String DELETE_ENTRIES =
             "DELETE altsystem_aenderung, op, st"
                     + " FROM altsystem_aenderung"
                     + "     LEFT JOIN altsystem_aenderung_operation op"
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 4"
-                    + "         AND altsystem_aenderung_created_at_utc >= DATE_SUB(NOW(), INTERVAL 1 MONTH)"
-                    + " ORDER BY aenderung_id";
-
+                    + "         where status = $status$"
+                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'";
     private final BasicDAO basicDAO;
 
 
@@ -205,33 +208,40 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAll() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
-    public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit) {
+    public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit) {
+    public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findNews(String multiplicator,String pageLimit) {
+    public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findErrors(String multiplicator,String pageLimit) {
+    public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> findInProgress(String multiplicator,String pageLimit) {
+    public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
+        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-    public List<TriggerBE> deleteSuccessedOneMonthAgo() {
-        return basicDAO.selectEntityList(TRIGGER,DELETE_ALL_SUCCESSED_ONE_MONTH_AGO);
+    public List<TriggerBE> deleteEntries(String status, String dateInterval) {
+        LOGGER.warn("Hier ist das dateInterval: " + dateInterval);
+        String changedSQL = DELETE_ENTRIES.replace("$status$", status).replace("$dateInterval$", dateInterval);
+        return basicDAO.selectEntityList(TRIGGER,DELETE_ENTRIES);
     }
 
     public List<TriggerBE> findAllUnprocessed() {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -144,6 +144,16 @@ public class TriggerDAO implements DataAccessObject {
                     + " ORDER BY aenderung_id"
                     + " LIMIT $limit$ OFFSET $offset$";
 
+    private static final String DELETE_ALL_SUCCESSED_ONE_MONTH_AGO =
+            "DELETE altsystem_aenderung, op, st"
+                    + " FROM altsystem_aenderung"
+                    + "     LEFT JOIN altsystem_aenderung_operation op"
+                    + "         ON altsystem_aenderung.operation = op.operation_id"
+                    + "     LEFT JOIN altsystem_aenderung_status st"
+                    + "         ON altsystem_aenderung.status = st.status_id"
+                    + "         where status = 4"
+                    + "         AND altsystem_aenderung_created_at_utc >= DATE_SUB(NOW(), INTERVAL 1 MONTH)"
+                    + " ORDER BY aenderung_id";
 
     private final BasicDAO basicDAO;
 
@@ -220,6 +230,10 @@ public class TriggerDAO implements DataAccessObject {
         String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset));
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
+    public List<TriggerBE> deleteSuccessedOneMonthAgo() {
+        return basicDAO.selectEntityList(TRIGGER,DELETE_ALL_SUCCESSED_ONE_MONTH_AGO);
+    }
+
     public List<TriggerBE> findAllUnprocessed() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_UNPROCESSED);
     }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
@@ -450,4 +450,44 @@ public class TriggerComponentImplTest {
 		// verify invocations
 		verify(triggerDAO, times(1)).findAllWithPages("0","500", "1 MONTH");
 	}
+	@Test
+	public void testDeleteNewEntries() {
+		// Call the method
+		triggerDAO.deleteEntries("Neu", "1 MONTH");
+
+		// Verify that triggerDAO.deleteEntries was called with the correct parameters
+		verify(triggerDAO).deleteEntries("Neu", "1 MONTH");
+	}
+	@Test
+	public void testDeleteErrorEntries() {
+		// Call the method
+		triggerDAO.deleteEntries("Fehlgeschlagen", "1 MONTH");
+
+		// Verify that triggerDAO.deleteEntries was called with the correct parameters
+		verify(triggerDAO).deleteEntries("Fehlgeschlagen", "1 MONTH");
+	}
+	@Test
+	public void testDeleteInProgressEntries() {
+		// Call the method
+		triggerDAO.deleteEntries("Laufend", "1 MONTH");
+
+		// Verify that triggerDAO.deleteEntries was called with the correct parameters
+		verify(triggerDAO).deleteEntries("Laufend", "1 MONTH");
+	}
+	@Test
+	public void testDeleteSuccessEntries() {
+		// Call the method
+		triggerDAO.deleteEntries("Erfolgreich", "1 MONTH");
+
+		// Verify that triggerDAO.deleteEntries was called with the correct parameters
+		verify(triggerDAO).deleteEntries("Erfolgreich", "1 MONTH");
+	}
+	@Test
+	public void testAllSuccessEntries() {
+		// Call the method
+		triggerDAO.deleteEntries("Alle", "1 MONTH");
+
+		// Verify that triggerDAO.deleteEntries was called with the correct parameters
+		verify(triggerDAO).deleteEntries("Alle", "1 MONTH");
+	}
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/business/TriggerComponentImplTest.java
@@ -257,10 +257,10 @@ public class TriggerComponentImplTest {
 		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
 		// configure mocks
-		when(triggerDAO.findErrors("0","500")).thenReturn(expectedBEList);
+		when(triggerDAO.findErrors("0","500", "1 MONTH")).thenReturn(expectedBEList);
 
 		// call test method
-		final List<TriggerDO> actual = underTest.findAllErrors("0","500");
+		final List<TriggerDO> actual = underTest.findAllErrors("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -288,7 +288,7 @@ public class TriggerComponentImplTest {
 				.isEqualTo(expectedBE.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerDAO, times(1)).findErrors("0","500");
+		verify(triggerDAO, times(1)).findErrors("0","500", "1 MONTH");
 	}
 	@Test
 	public void findAllNews() {
@@ -297,10 +297,10 @@ public class TriggerComponentImplTest {
 		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
 		// configure mocks
-		when(triggerDAO.findNews("0","500")).thenReturn(expectedBEList);
+		when(triggerDAO.findNews("0","500", "1 MONTH")).thenReturn(expectedBEList);
 
 		// call test method
-		final List<TriggerDO> actual = underTest.findAllNews("0","500");
+		final List<TriggerDO> actual = underTest.findAllNews("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -328,7 +328,7 @@ public class TriggerComponentImplTest {
 				.isEqualTo(expectedBE.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerDAO, times(1)).findNews("0","500");
+		verify(triggerDAO, times(1)).findNews("0","500", "1 MONTH");
 	}
 	@Test
 	public void findAllSuccess() {
@@ -337,10 +337,10 @@ public class TriggerComponentImplTest {
 		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
 		// configure mocks
-		when(triggerDAO.findSuccessed("0","500")).thenReturn(expectedBEList);
+		when(triggerDAO.findSuccessed("0","500", "1 MONTH")).thenReturn(expectedBEList);
 
 		// call test method
-		final List<TriggerDO> actual = underTest.findAllSuccessed("0","500");
+		final List<TriggerDO> actual = underTest.findAllSuccessed("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -368,7 +368,7 @@ public class TriggerComponentImplTest {
 				.isEqualTo(expectedBE.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerDAO, times(1)).findSuccessed("0","500");
+		verify(triggerDAO, times(1)).findSuccessed("0","500", "1 MONTH");
 	}
 	@Test
 	public void findAllInProgress() {
@@ -377,10 +377,10 @@ public class TriggerComponentImplTest {
 		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
 		// configure mocks
-		when(triggerDAO.findInProgress("0","500")).thenReturn(expectedBEList);
+		when(triggerDAO.findInProgress("0","500", "1 MONTH")).thenReturn(expectedBEList);
 
 		// call test method
-		final List<TriggerDO> actual = underTest.findAllInProgress("0","500");
+		final List<TriggerDO> actual = underTest.findAllInProgress("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -408,7 +408,7 @@ public class TriggerComponentImplTest {
 				.isEqualTo(expectedBE.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerDAO, times(1)).findInProgress("0","500");
+		verify(triggerDAO, times(1)).findInProgress("0","500", "1 MONTH");
 	}
 	@Test
 	public void findAllWithPages() {
@@ -417,10 +417,10 @@ public class TriggerComponentImplTest {
 		final List<TriggerBE> expectedBEList = Collections.singletonList(expectedBE);
 
 		// configure mocks
-		when(triggerDAO.findAllWithPages("0","500")).thenReturn(expectedBEList);
+		when(triggerDAO.findAllWithPages("0","500", "1 MONTH")).thenReturn(expectedBEList);
 
 		// call test method
-		final List<TriggerDO> actual = underTest.findAllWithPages("0","500");
+		final List<TriggerDO> actual = underTest.findAllWithPages("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -448,6 +448,6 @@ public class TriggerComponentImplTest {
 				.isEqualTo(expectedBE.getRunAtUtc());
 
 		// verify invocations
-		verify(triggerDAO, times(1)).findAllWithPages("0","500");
+		verify(triggerDAO, times(1)).findAllWithPages("0","500", "1 MONTH");
 	}
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
@@ -24,7 +24,7 @@ import static de.bogenliga.application.business.trigger.impl.business.TriggerCom
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the TriggerDAO class
@@ -237,4 +237,51 @@ public class TriggerDAOTest {
 
 		assertThat(actual.get(0)).isNotNull();
 	}
+	@Test
+	public void testDeleteEntriesSuccess() {
+		// Call test method
+		triggerDAO.deleteEntries("Erfolgreich", "1 MONTH");
+
+		// Verify that basicDAO.executeQuery was called with the correct SQL
+		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 4 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
+		verify(basicDAO).executeQuery(expectedSQL);
+	}
+	@Test
+	public void testDeleteEntriesNew() {
+		// Call test method
+		triggerDAO.deleteEntries("Neu", "1 MONTH");
+
+		// Verify that basicDAO.executeQuery was called with the correct SQL
+		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 1 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
+		verify(basicDAO).executeQuery(expectedSQL);
+	}
+	@Test
+	public void testDeleteEntriesError() {
+		// Call test method
+		triggerDAO.deleteEntries("Fehlgeschlagen", "1 MONTH");
+
+		// Verify that basicDAO.executeQuery was called with the correct SQL
+		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 3 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
+		verify(basicDAO).executeQuery(expectedSQL);
+	}
+	@Test
+	public void testDeleteEntriesInProgress() {
+		// Call test method
+		triggerDAO.deleteEntries("Laufend", "1 MONTH");
+
+		// Verify that basicDAO.executeQuery was called with the correct SQL
+		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 2 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
+		verify(basicDAO).executeQuery(expectedSQL);
+	}
+	@Test
+	public void testDeleteEntriesAll() {
+		// Call test method
+		triggerDAO.deleteEntries("Alle", "1 MONTH");
+
+		// Verify that basicDAO.executeQuery was called with the correct SQL
+		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
+		verify(basicDAO).executeQuery(expectedSQL);
+	}
 }
+
+

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
@@ -151,7 +151,7 @@ public class TriggerDAOTest {
 		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
 		// call test method
-		final List<TriggerBE> actual = triggerDAO.findErrors("0","500");
+		final List<TriggerBE> actual = triggerDAO.findErrors("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -170,7 +170,7 @@ public class TriggerDAOTest {
 		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
 		// call test method
-		final List<TriggerBE> actual = triggerDAO.findNews("0","500");
+		final List<TriggerBE> actual = triggerDAO.findNews("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -189,7 +189,7 @@ public class TriggerDAOTest {
 		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
 		// call test method
-		final List<TriggerBE> actual = triggerDAO.findSuccessed("0","500");
+		final List<TriggerBE> actual = triggerDAO.findSuccessed("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -208,7 +208,7 @@ public class TriggerDAOTest {
 		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
 		// call test method
-		final List<TriggerBE> actual = triggerDAO.findInProgress("0","500");
+		final List<TriggerBE> actual = triggerDAO.findInProgress("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)
@@ -227,7 +227,7 @@ public class TriggerDAOTest {
 		when(basicDAO.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
 		// call test method
-		final List<TriggerBE> actual = triggerDAO.findAllWithPages("0","500");
+		final List<TriggerBE> actual = triggerDAO.findAllWithPages("0","500", "1 MONTH");
 
 		// assert result
 		assertThat(actual)


### PR DESCRIPTION
Wir haben das löschen vom Protokoll der Datenmigration umgesetzt, man kann jetzt ebenfalls für Zeitstempel filtern. Nachdem man alles gefiltert hat kann man alle gefilterten Protokolle mit einem Button löschen lassen. Tests wurden auch implementiert.