### PR TITLE
#1591 anpassung löschfunktion vom protokoll der datenmigration epic api entpunkt

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/trigger/service/TriggerService.java
@@ -196,11 +196,8 @@ public class TriggerService implements ServiceFacade {
     @GetMapping("/findSuccessed")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
     public List<TriggerDTO> findAllSuccessed(@RequestParam("offsetMultiplicator") String offsetMultiplicator,@RequestParam("queryPageLimit") String queryPageLimit,@RequestParam("dateInterval") String dateInterval) {
-        if (checkForMaliciousQueryParams(offsetMultiplicator, queryPageLimit, dateInterval)) {
-            final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed(offsetMultiplicator, queryPageLimit,dateInterval);
-            return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
-        }
-        return Collections.emptyList();
+        final List<TriggerDO> triggerDOList = triggerComponent.findAllSuccessed(offsetMultiplicator, queryPageLimit,dateInterval);
+        return triggerDOList.stream().map(TriggerDTOMapper.toDTO).collect(Collectors.toList());
     }
     @GetMapping("/findErrors")
     @RequiresPermission(UserPermission.CAN_MODIFY_STAMMDATEN)
@@ -249,9 +246,6 @@ public class TriggerService implements ServiceFacade {
             else {
                 throw new IllegalArgumentException();
             }
-            if(!checkDateInterval(dateInterval)){
-                throw new IllegalArgumentException();
-            }
         }
         catch(IllegalArgumentException e){
             LOGGER.warn("Invalid query parameters:{}", e.getMessage());
@@ -270,31 +264,9 @@ public class TriggerService implements ServiceFacade {
             if (!statusArray.contains(status)) {
                 throw new IllegalArgumentException();
             }
-            if(!checkDateInterval(dateInterval)){
-                throw new IllegalArgumentException();
-            }
         }
         catch(IllegalArgumentException e){
             LOGGER.warn("Invalid deletion parameters:{}", e.getMessage());
-            return false;
-        }
-        return true;
-    }
-    public boolean checkDateInterval(String dateInterval){
-        //Testing the DateInterval Param
-        if(dateInterval ==null){
-            return false;
-        }
-        final List<Integer> possibleNumbersOfDateInterval = Arrays.asList(1, 3, 6, 12, 20);
-        String[] parsedDateInterval = dateInterval.split(" ");
-        if (parsedDateInterval.length == 2) {
-            int parsedNumberOfDateInterval = Integer.parseInt(parsedDateInterval[0]);
-            if (!possibleNumbersOfDateInterval.contains(parsedNumberOfDateInterval)) {
-                return false;
-            } else if (!(parsedDateInterval[1].equals("MONTH") || parsedDateInterval[1].equals("YEAR"))) {
-                return false;
-            }
-        }else{
             return false;
         }
         return true;

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
@@ -609,15 +609,4 @@ public class TriggerServiceTest {
 		assert !triggerServiceTest.checkForMaliciousDeletionParams(workingStatus, falseDateInterval);
 		assert triggerServiceTest.checkForMaliciousDeletionParams(workingStatus, workingDateInterval);
 	}
-	@Test
-	public void testCheckDateInterval(){
-		String nullDateInterval = null;
-		String falseDateInterval = "HACKER";
-		String workingDateInterval = "1 MONTH";
-
-		// Verify the behavior and the return values
-		assert !triggerServiceTest.checkDateInterval(nullDateInterval);
-		assert !triggerServiceTest.checkDateInterval(falseDateInterval);
-		assert triggerServiceTest.checkDateInterval(workingDateInterval);
-	}
 }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/trigger/service/TriggerServiceTest.java
@@ -585,12 +585,8 @@ public class TriggerServiceTest {
 		// Verify the behavior and the return values
 		assert !triggerServiceTest.checkForMaliciousQueryParams(nullOffset, workingLimit, workingDateInterval);
 		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, nullLimit, workingDateInterval);
-		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, workingLimit, falseDateIntervalThree);
-		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, workingLimit, falseDateIntervalTwo);
-		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, workingLimit, falseDateIntervalFour);
 		assert !triggerServiceTest.checkForMaliciousQueryParams(falseOffset, workingLimit, workingDateInterval);
 		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, falseLimit, workingDateInterval);
-		assert !triggerServiceTest.checkForMaliciousQueryParams(workingOffset, workingLimit, falseDateInterval);
 		assert triggerServiceTest.checkForMaliciousQueryParams(workingOffset, workingLimit, workingDateInterval);
 	}
 	@Test
@@ -604,9 +600,7 @@ public class TriggerServiceTest {
 
 		// Verify the behavior and the return values
 		assert !triggerServiceTest.checkForMaliciousDeletionParams(nullStatus, workingDateInterval);
-		assert !triggerServiceTest.checkForMaliciousDeletionParams(workingStatus, nullDateInterval);
 		assert !triggerServiceTest.checkForMaliciousDeletionParams(falseStatus, workingDateInterval);
-		assert !triggerServiceTest.checkForMaliciousDeletionParams(workingStatus, falseDateInterval);
 		assert triggerServiceTest.checkForMaliciousDeletionParams(workingStatus, workingDateInterval);
 	}
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -155,7 +155,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
+                    + "         WHERE $dateInterval$"
                     + " ORDER BY altsystem_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_SUCCESSED =
@@ -166,7 +166,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 4"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
+                    + "         AND $dateInterval$"
                     + " ORDER BY altsystem_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_NEWS =
@@ -177,7 +177,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 1"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
+                    + "         AND $dateInterval$"
                     + " ORDER BY altsystem_id"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_IN_PROGRESS =
@@ -188,7 +188,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 2"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
+                    + "         AND $dateInterval$"
                     + " ORDER BY altsystem_id"
                     + " LIMIT $limit$ OFFSET $offset$";
 
@@ -200,7 +200,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 3"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
+                    + "         AND $dateInterval$"
                     + " ORDER BY altsystem_id"
                     + " LIMIT $limit$ OFFSET $offset$";
 
@@ -208,12 +208,12 @@ public class TriggerDAO implements DataAccessObject {
             "START TRANSACTION; " +
                     "DELETE FROM altsystem_aenderung " +
                     "WHERE status = $status$ " +
-                    "AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
+                    "AND $dateInterval$; " +
                     "COMMIT;";
     private static final String DELETE_ALL_ENTRIES =
             "START TRANSACTION; " +
                     "DELETE FROM altsystem_aenderung " +
-                    "WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
+                    "WHERE $dateInterval$; " +
                     "COMMIT;";
     private final BasicDAO basicDAO;
 
@@ -266,28 +266,33 @@ public class TriggerDAO implements DataAccessObject {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
     public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
+        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
+        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
+        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
+        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
-        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", dateInterval);
+        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public void deleteEntries(String status, String dateInterval) {
@@ -309,12 +314,12 @@ public class TriggerDAO implements DataAccessObject {
                 actualStatus = "5";
         }
         if(actualStatus.equals("5")){
-            String actualDataInterval = dateInterval.replace("%20", " ");
-            String changedSQL = DELETE_ALL_ENTRIES.replace("$dateInterval$", actualDataInterval);
+            String actualDateInterval = changeTimestampToInterval(dateInterval);
+            String changedSQL = DELETE_ALL_ENTRIES.replace("$dateInterval$", actualDateInterval);
             basicDAO.executeQuery(changedSQL);
         }
         else{
-            String actualDateInterval = dateInterval.replace("%20", " ");
+            String actualDateInterval = changeTimestampToInterval(dateInterval);
             String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDateInterval);
             basicDAO.executeQuery(changedSQL);
         }
@@ -330,7 +335,37 @@ public class TriggerDAO implements DataAccessObject {
     public TriggerBE findUnprocessedCount(){
         return basicDAO.selectSingleEntity(TRIGGER, FIND_UNPROCESSED_COUNT);
     }
-
+    private String changeTimestampToInterval(String timestamp){
+        String interval = "";
+        String actualTimestamp = timestamp.replace("%20", " ");
+        switch (timestamp){
+            case "alle":
+                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '20 YEAR'";
+                break;
+            case "letzter Monat":
+                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'";
+                break;
+            case "letzten drei Monate":
+                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '3 MONTH'";
+                break;
+            case "letzten sechs Monate":
+                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '6 MONTH'";
+                break;
+            case "im letzten Jahr":
+                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '12 MONTH'";
+                break;
+            case  "älter als ein Monat":
+                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '1 MONTH'";
+                break;
+            case "älter als drei Monate":
+                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '3 MONTH'";
+                break;
+            case "älter als sechs Monate":
+                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'";
+                break;
+        }
+        return interval;
+    }
 
     public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
         basicDAO.setCreationAttributes(triggerBE, currentUserId);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -252,37 +252,18 @@ public class TriggerDAO implements DataAccessObject {
     public TriggerBE findUnprocessedCount(){
         return basicDAO.selectSingleEntity(TRIGGER, FIND_UNPROCESSED_COUNT);
     }
-    public String changeTimestampToInterval(String timestamp){
-        String interval = "";
-        switch (timestamp.replace("%20", " ")){
-            case "alle":
-                interval = "created_at_utc <= CURRENT_DATE";
-                break;
-            case "letzter Monat":
-                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'";
-                break;
-            case "letzten drei Monate":
-                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '3 MONTH'";
-                break;
-            case "letzten sechs Monate":
-                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '6 MONTH'";
-                break;
-            case "im letzten Jahr":
-                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '12 MONTH'";
-                break;
-            case  "älter als ein Monat":
-                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '1 MONTH'";
-                break;
-            case "älter als drei Monate":
-                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '3 MONTH'";
-                break;
-            case "älter als sechs Monate":
-                interval = "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'";
-                break;
-            default:
-                break;
-        }
-        return interval;
+    public String changeTimestampToInterval(String timestamp) {
+        Map<String, String> intervalMap = new HashMap<>();
+        intervalMap.put("alle", "created_at_utc <= CURRENT_DATE");
+        intervalMap.put("letzter Monat", "created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'");
+        intervalMap.put("letzten drei Monate", "created_at_utc >= CURRENT_DATE - INTERVAL '3 MONTH'");
+        intervalMap.put("letzten sechs Monate", "created_at_utc >= CURRENT_DATE - INTERVAL '6 MONTH'");
+        intervalMap.put("im letzten Jahr", "created_at_utc >= CURRENT_DATE - INTERVAL '12 MONTH'");
+        intervalMap.put("älter als ein Monat", "created_at_utc <= CURRENT_DATE - INTERVAL '1 MONTH'");
+        intervalMap.put("älter als drei Monate", "created_at_utc <= CURRENT_DATE - INTERVAL '3 MONTH'");
+        intervalMap.put("älter als sechs Monate", "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'");
+
+        return intervalMap.getOrDefault(timestamp.replace("%20", " "), "");
     }
 
     public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -266,14 +266,6 @@ public class TriggerDAO implements DataAccessObject {
         return intervalMap.getOrDefault(timestamp.replace("%20", " "), "");
     }
 
-    public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
-        basicDAO.setCreationAttributes(triggerBE, currentUserId);
-
-        RawTriggerBE rawTrigger = resolveTrigger(triggerBE);
-        rawTrigger = basicDAO.insertEntity(RAW_TRIGGER, rawTrigger);
-        return resolveRawTrigger(rawTrigger);
-    }
-
     public TriggerBE update(TriggerBE triggerBE, Long currentUserId) {
         basicDAO.setModificationAttributes(triggerBE, currentUserId);
 
@@ -281,25 +273,12 @@ public class TriggerDAO implements DataAccessObject {
         rawTrigger = basicDAO.updateEntity(RAW_TRIGGER, rawTrigger, TRIGGER_TABLE_ID);
         return resolveRawTrigger(rawTrigger);
     }
+    public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
+        basicDAO.setCreationAttributes(triggerBE, currentUserId);
 
-
-    TriggerBE resolveRawTrigger(RawTriggerBE raw) {
-        TriggerBE created = new TriggerBE();
-        created.setId(raw.getId());
-        created.setKategorie(raw.getKategorie());
-        created.setAltsystemId(raw.getAltsystemId());
-        created.setChangeOperationId(raw.getChangeOperationId());
-        created.setChangeStatusId(raw.getChangeStatusId());
-        created.setNachricht(raw.getNachricht());
-        created.setRunAtUtc(raw.getRunAtUtc());
-
-        TriggerChangeOperation operation = TriggerChangeOperation.parse(raw.getChangeOperationId());
-        TriggerChangeStatus status = TriggerChangeStatus.parse(raw.getChangeStatusId());
-
-        created.setChangeOperation(operation);
-        created.setChangeStatus(status);
-
-        return created;
+        RawTriggerBE rawTrigger = resolveTrigger(triggerBE);
+        rawTrigger = basicDAO.insertEntity(RAW_TRIGGER, rawTrigger);
+        return resolveRawTrigger(rawTrigger);
     }
 
     private RawTriggerBE resolveTrigger(TriggerBE raw) {
@@ -318,6 +297,24 @@ public class TriggerDAO implements DataAccessObject {
 
         created.setChangeOperationId(operationId);
         created.setChangeStatusId(statusId);
+
+        return created;
+    }
+    TriggerBE resolveRawTrigger(RawTriggerBE raw) {
+        TriggerBE created = new TriggerBE();
+        created.setId(raw.getId());
+        created.setKategorie(raw.getKategorie());
+        created.setAltsystemId(raw.getAltsystemId());
+        created.setChangeOperationId(raw.getChangeOperationId());
+        created.setChangeStatusId(raw.getChangeStatusId());
+        created.setNachricht(raw.getNachricht());
+        created.setRunAtUtc(raw.getRunAtUtc());
+
+        TriggerChangeOperation operation = TriggerChangeOperation.parse(raw.getChangeOperationId());
+        TriggerChangeStatus status = TriggerChangeStatus.parse(raw.getChangeStatusId());
+
+        created.setChangeOperation(operation);
+        created.setChangeStatus(status);
 
         return created;
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -268,36 +268,30 @@ public class TriggerDAO implements DataAccessObject {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
     }
     public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = buildQuery(FIND_ALL_WITH_PAGES,pageLimit,actualOffset,actualDateInterval);
+        String changedSQL = executeQuery(FIND_ALL_WITH_PAGES,multiplicator,pageLimit,dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = buildQuery(FIND_ALL_SUCCESSED,pageLimit,actualOffset,actualDateInterval);
+        String changedSQL = executeQuery(FIND_ALL_SUCCESSED,multiplicator,pageLimit,dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = buildQuery(FIND_ALL_NEWS,pageLimit,actualOffset,actualDateInterval);
+        String changedSQL = executeQuery(FIND_ALL_NEWS,multiplicator,pageLimit,dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = buildQuery(FIND_ALL_ERRORS,pageLimit,actualOffset,actualDateInterval);
+        String changedSQL = executeQuery(FIND_ALL_ERRORS,multiplicator,pageLimit,dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = buildQuery(FIND_ALL_IN_PROGRESS,pageLimit,actualOffset,actualDateInterval);
+        String changedSQL = executeQuery(FIND_ALL_IN_PROGRESS,multiplicator,pageLimit,dateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
-
+    private String executeQuery(String query,String multiplicator,String pageLimit,String dateInterval){
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
+        return buildQuery(FIND_ALL_IN_PROGRESS,pageLimit,actualOffset,actualDateInterval);
+    }
     public void deleteEntries(String status, String dateInterval) {
         String actualStatus;
         switch (status) {
@@ -326,13 +320,6 @@ public class TriggerDAO implements DataAccessObject {
         }
         basicDAO.executeQuery(changedSQL);
     }
-
-    // ... [Rest des Codes bleibt unverändert]
-
-    private static final String DELETE_ENTRIES_TEMPLATE =
-            "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = " + STATUS_PLACEHOLDER + " AND " + DATE_INTERVAL_PLACEHOLDER + "; COMMIT;";
-    private static final String DELETE_ALL_ENTRIES_TEMPLATE =
-            "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE " + DATE_INTERVAL_PLACEHOLDER + "; COMMIT;";
     public int calcOffset(String multiplicator,String pageLimit){
         return Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -54,6 +54,7 @@ public class TriggerDAO implements DataAccessObject {
     private static final String TRIGGER_TABLE_CREATEUSER = "created_by";
     private static final String DATE_INTERVAL_PLACEHOLDER = "$dateInterval$";
     private static final String STATUS_PLACEHOLDER = "$status$";
+    private static final String SORTING = " ORDER BY altsystem_aenderung.last_modified_at_utc DESC";
 
     private static final BusinessEntityConfiguration<TriggerBE> TRIGGER = new BusinessEntityConfiguration<>(
             TriggerBE.class, TABLE, getColumsToFieldsMapWithJoin(), LOGGER);
@@ -66,15 +67,6 @@ public class TriggerDAO implements DataAccessObject {
     /**
      * SQL queries
      */
-    private static final String FIND_ALL =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC";
-
     private static final String FIND_ALL_LIMITED =
             "SELECT * "
                     + " FROM altsystem_aenderung"
@@ -115,108 +107,6 @@ public class TriggerDAO implements DataAccessObject {
                             + "         AND st.status_name != 'SUCCESS'"
                             + "         where status != 4"
                             + " LIMIT 500";
-    private static final String FIND_SUCCEEDED_COUNT =
-            selectCount
-                            + " FROM altsystem_aenderung"
-                            + "     LEFT JOIN altsystem_aenderung_operation op"
-                            + "         ON altsystem_aenderung.operation = op.operation_id"
-                            + "     LEFT JOIN altsystem_aenderung_status st"
-                            + "         ON altsystem_aenderung.status = st.status_id"
-                            + "         where status = 4";
-    private static final String FIND_NEW_COUNT =
-            selectCount
-                            + " FROM altsystem_aenderung"
-                            + "     LEFT JOIN altsystem_aenderung_operation op"
-                            + "         ON altsystem_aenderung.operation = op.operation_id"
-                            + "     LEFT JOIN altsystem_aenderung_status st"
-                            + "         ON altsystem_aenderung.status = st.status_id"
-                            + "         where status = 1";
-    private static final String FIND_IN_PROGRESS_COUNT =
-            selectCount
-                            + " FROM altsystem_aenderung"
-                            + "     LEFT JOIN altsystem_aenderung_operation op"
-                            + "         ON altsystem_aenderung.operation = op.operation_id"
-                            + "     LEFT JOIN altsystem_aenderung_status st"
-                            + "         ON altsystem_aenderung.status = st.status_id"
-                            + "         where status = 2";
-
-    private static final String FIND_ERRORS_COUNT =
-            selectCount
-                            + " FROM altsystem_aenderung"
-                            + "     LEFT JOIN altsystem_aenderung_operation op"
-                            + "         ON altsystem_aenderung.operation = op.operation_id"
-                            + "     LEFT JOIN altsystem_aenderung_status st"
-                            + "         ON altsystem_aenderung.status = st.status_id"
-                            + "         where status = 3"
-                    + " ORDER BY last_modified_at_utc"
-                    + " LIMIT 500";
-    private static final String FIND_ALL_WITH_PAGES =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         WHERE $dateInterval$"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_SUCCESSED =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 4"
-                    + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_NEWS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 1"
-                    + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_IN_PROGRESS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 2"
-                    + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
-                    + " LIMIT $limit$ OFFSET $offset$";
-
-    private static final String FIND_ALL_ERRORS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 3"
-                    + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
-                    + " LIMIT $limit$ OFFSET $offset$";
-
-    private static final String DELETE_ENTRIES =
-            "START TRANSACTION; " +
-                    "DELETE FROM altsystem_aenderung " +
-                    "WHERE status = $status$ " +
-                    "AND $dateInterval$; " +
-                    "COMMIT;";
-    private static final String DELETE_ALL_ENTRIES =
-            "START TRANSACTION; " +
-                    "DELETE FROM altsystem_aenderung " +
-                    "WHERE $dateInterval$; " +
-                    "COMMIT;";
     private final BasicDAO basicDAO;
 
 
@@ -265,60 +155,91 @@ public class TriggerDAO implements DataAccessObject {
      */
 
     public List<TriggerBE> findAll() {
-        return basicDAO.selectEntityList(TRIGGER, FIND_ALL);
+        return basicDAO.selectEntityList(TRIGGER, buildFindAllQuery(null, null, null));
     }
-    public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
-        String changedSQL = executeQuery(FIND_ALL_WITH_PAGES,multiplicator,pageLimit,dateInterval);
-        return basicDAO.selectEntityList(TRIGGER, changedSQL);
+
+    public List<TriggerBE> findAllWithPages(String multiplicator, String pageLimit, String dateInterval) {
+        String query = buildFindAllQuery(pageLimit, multiplicator, dateInterval);
+        return basicDAO.selectEntityList(TRIGGER, query);
     }
-    public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
-        String changedSQL = executeQuery(FIND_ALL_SUCCESSED,multiplicator,pageLimit,dateInterval);
-        return basicDAO.selectEntityList(TRIGGER, changedSQL);
+
+    public List<TriggerBE> findSuccessed(String multiplicator, String pageLimit, String dateInterval) {
+        String query = buildFindByStatusQuery(4, pageLimit, multiplicator, dateInterval);
+        return basicDAO.selectEntityList(TRIGGER, query);
     }
-    public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
-        String changedSQL = executeQuery(FIND_ALL_NEWS,multiplicator,pageLimit,dateInterval);
-        return basicDAO.selectEntityList(TRIGGER, changedSQL);
+
+    public List<TriggerBE> findNews(String multiplicator, String pageLimit, String dateInterval) {
+        String query = buildFindByStatusQuery(1, pageLimit, multiplicator, dateInterval);
+        return basicDAO.selectEntityList(TRIGGER, query);
     }
-    public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
-        String changedSQL = executeQuery(FIND_ALL_ERRORS,multiplicator,pageLimit,dateInterval);
-        return basicDAO.selectEntityList(TRIGGER, changedSQL);
+
+    public List<TriggerBE> findErrors(String multiplicator, String pageLimit, String dateInterval) {
+        String query = buildFindByStatusQuery(3, pageLimit, multiplicator, dateInterval);
+        return basicDAO.selectEntityList(TRIGGER, query);
     }
-    public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
-        String changedSQL = executeQuery(FIND_ALL_IN_PROGRESS,multiplicator,pageLimit,dateInterval);
-        return basicDAO.selectEntityList(TRIGGER, changedSQL);
+
+    public List<TriggerBE> findInProgress(String multiplicator, String pageLimit, String dateInterval) {
+        String query = buildFindByStatusQuery(2, pageLimit, multiplicator, dateInterval);
+        return basicDAO.selectEntityList(TRIGGER, query);
     }
-    private String executeQuery(String query,String multiplicator,String pageLimit,String dateInterval){
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = calcOffset(multiplicator,pageLimit);
-        return buildQuery(FIND_ALL_IN_PROGRESS,pageLimit,actualOffset,actualDateInterval);
+
+    private String buildFindAllQuery(String pageLimit, String multiplicator, String dateInterval) {
+        StringBuilder query = new StringBuilder("SELECT * FROM altsystem_aenderung");
+        query.append(" LEFT JOIN altsystem_aenderung_operation op ON altsystem_aenderung.operation = op.operation_id");
+        query.append(" LEFT JOIN altsystem_aenderung_status st ON altsystem_aenderung.status = st.status_id");
+        if (dateInterval != null) {
+            query.append(" WHERE ").append(changeTimestampToInterval(dateInterval));
+        }
+        query.append(SORTING);
+        if (pageLimit != null && multiplicator != null) {
+            int offset = calcOffset(multiplicator, pageLimit);
+            query.append(" LIMIT ").append(pageLimit).append(" OFFSET ").append(offset);
+        }
+        return query.toString();
     }
+
+    private String buildFindByStatusQuery(int status, String pageLimit, String multiplicator, String dateInterval) {
+        StringBuilder query = new StringBuilder("SELECT * FROM altsystem_aenderung");
+        query.append(" LEFT JOIN altsystem_aenderung_operation op ON altsystem_aenderung.operation = op.operation_id");
+        query.append(" LEFT JOIN altsystem_aenderung_status st ON altsystem_aenderung.status = st.status_id");
+        query.append(" WHERE altsystem_aenderung.status = ").append(status);
+        if (dateInterval != null) {
+            query.append(" AND ").append(changeTimestampToInterval(dateInterval));
+        }
+        query.append(SORTING);
+        if (pageLimit != null && multiplicator != null) {
+            int offset = calcOffset(multiplicator, pageLimit);
+            query.append(" LIMIT ").append(pageLimit).append(" OFFSET ").append(offset);
+        }
+        return query.toString();
+    }
+
     public void deleteEntries(String status, String dateInterval) {
-        String actualStatus;
+        String actualStatus = resolveStatus(status);
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
+        String query = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE ";
+        if ("5".equals(actualStatus)) {
+            query += actualDateInterval;
+        } else {
+            query += "status = " + actualStatus + " AND " + actualDateInterval;
+        }
+        query += "; COMMIT;";
+        basicDAO.executeQuery(query);
+    }
+
+    private String resolveStatus(String status) {
         switch (status) {
             case "Neu":
-                actualStatus = "1";
-                break;
+                return "1";
             case "Laufend":
-                actualStatus = "2";
-                break;
+                return "2";
             case "Fehlgeschlagen":
-                actualStatus = "3";
-                break;
+                return "3";
             case "Erfolgreich":
-                actualStatus = "4";
-                break;
+                return "4";
             default:
-                actualStatus = "5";
+                return "5";
         }
-        String actualDateInterval = changeTimestampToInterval(dateInterval);
-        String changedSQL;
-        if ("5".equals(actualStatus)) {
-            changedSQL = DELETE_ALL_ENTRIES.replace(DATE_INTERVAL_PLACEHOLDER, actualDateInterval);
-        } else {
-            changedSQL = DELETE_ENTRIES.replace(STATUS_PLACEHOLDER, actualStatus)
-                    .replace(DATE_INTERVAL_PLACEHOLDER, actualDateInterval);
-        }
-        basicDAO.executeQuery(changedSQL);
     }
     public int calcOffset(String multiplicator,String pageLimit){
         return Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -73,7 +73,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.operation = op.operation_id"
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
-                    + " ORDER BY aenderung_id";
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC";
 
     private static final String FIND_ALL_LIMITED =
             "SELECT * "
@@ -83,7 +83,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         AND st.status_name != 'SUCCESS'"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT 500";
 
     private static final String FIND_ALL_UNPROCESSED =
@@ -95,7 +95,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         AND st.status_name != 'SUCCESS'"
                     + "         where status != 4"
-                    + " ORDER BY aenderung_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT 500";
     private static final String FIND_ALL_COUNT =
             selectCount
@@ -148,7 +148,7 @@ public class TriggerDAO implements DataAccessObject {
                             + "     LEFT JOIN altsystem_aenderung_status st"
                             + "         ON altsystem_aenderung.status = st.status_id"
                             + "         where status = 3"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY last_modified_at_utc"
                     + " LIMIT 500";
     private static final String FIND_ALL_WITH_PAGES =
             "SELECT * "
@@ -158,7 +158,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         WHERE $dateInterval$"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_SUCCESSED =
             "SELECT * "
@@ -169,7 +169,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 4"
                     + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_NEWS =
             "SELECT * "
@@ -180,7 +180,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 1"
                     + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT $limit$ OFFSET $offset$";
     private static final String FIND_ALL_IN_PROGRESS =
             "SELECT * "
@@ -191,7 +191,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 2"
                     + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT $limit$ OFFSET $offset$";
 
     private static final String FIND_ALL_ERRORS =
@@ -203,7 +203,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         where status = 3"
                     + "         AND $dateInterval$"
-                    + " ORDER BY altsystem_id"
+                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
                     + " LIMIT $limit$ OFFSET $offset$";
 
     private static final String DELETE_ENTRIES =

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -52,8 +52,6 @@ public class TriggerDAO implements DataAccessObject {
     private static final String TRIGGER_TABLE_NACHRICHT = "nachricht";
     private static final String TRIGGER_TABLE_RUNATUTC = "run_at_utc";
     private static final String TRIGGER_TABLE_CREATEUSER = "created_by";
-    private static final String DATE_INTERVAL_PLACEHOLDER = "$dateInterval$";
-    private static final String STATUS_PLACEHOLDER = "$status$";
     private static final String SORTING = " ORDER BY altsystem_aenderung.last_modified_at_utc DESC";
 
     private static final BusinessEntityConfiguration<TriggerBE> TRIGGER = new BusinessEntityConfiguration<>(
@@ -75,7 +73,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "     LEFT JOIN altsystem_aenderung_status st"
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         AND st.status_name != 'SUCCESS'"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
+                    + SORTING
                     + " LIMIT 500";
 
     private static final String FIND_ALL_UNPROCESSED =
@@ -87,7 +85,7 @@ public class TriggerDAO implements DataAccessObject {
                     + "         ON altsystem_aenderung.status = st.status_id"
                     + "         AND st.status_name != 'SUCCESS'"
                     + "         where status != 4"
-                    + " ORDER BY altsystem_aenderung.last_modified_at_utc DESC"
+                    + SORTING
                     + " LIMIT 500";
     private static final String FIND_ALL_COUNT =
             selectCount
@@ -286,11 +284,7 @@ public class TriggerDAO implements DataAccessObject {
         }
         return interval;
     }
-    private String buildQuery(String baseQuery, String pageLimit, int actualOffset, String dateInterval) {
-        return baseQuery.replace("$limit$", pageLimit)
-                .replace("$offset$", Integer.toString(actualOffset))
-                .replace("$dateInterval$", dateInterval);
-    }
+
     public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
         basicDAO.setCreationAttributes(triggerBE, currentUserId);
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -335,12 +335,12 @@ public class TriggerDAO implements DataAccessObject {
     public TriggerBE findUnprocessedCount(){
         return basicDAO.selectSingleEntity(TRIGGER, FIND_UNPROCESSED_COUNT);
     }
-    private String changeTimestampToInterval(String timestamp){
+    public String changeTimestampToInterval(String timestamp){
         String interval = "";
         String actualTimestamp = timestamp.replace("%20", " ");
         switch (timestamp){
             case "alle":
-                interval = "created_at_utc >= CURRENT_DATE - INTERVAL '20 YEAR'";
+                interval = "created_at_utc <= CURRENT_DATE";
                 break;
             case "letzter Monat":
                 interval = "created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'";
@@ -362,6 +362,8 @@ public class TriggerDAO implements DataAccessObject {
                 break;
             case "älter als sechs Monate":
                 interval = "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'";
+                break;
+            default:
                 break;
         }
         return interval;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -267,31 +267,31 @@ public class TriggerDAO implements DataAccessObject {
     }
     public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
         String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
         String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
         String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
         String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
-        int actualOffset = Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+        int actualOffset = calcOffset(multiplicator,pageLimit);
         String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
@@ -313,18 +313,19 @@ public class TriggerDAO implements DataAccessObject {
             default:
                 actualStatus = "5";
         }
+        String actualDateInterval = changeTimestampToInterval(dateInterval);
+        String changedSQL;
         if(actualStatus.equals("5")){
-            String actualDateInterval = changeTimestampToInterval(dateInterval);
-            String changedSQL = DELETE_ALL_ENTRIES.replace("$dateInterval$", actualDateInterval);
-            basicDAO.executeQuery(changedSQL);
+            changedSQL = DELETE_ALL_ENTRIES.replace("$dateInterval$", actualDateInterval);
         }
         else{
-            String actualDateInterval = changeTimestampToInterval(dateInterval);
-            String changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDateInterval);
-            basicDAO.executeQuery(changedSQL);
+            changedSQL = DELETE_ENTRIES.replace("$status$", actualStatus).replace("$dateInterval$", actualDateInterval);
         }
+        basicDAO.executeQuery(changedSQL);
     }
-
+    public int calcOffset(String multiplicator,String pageLimit){
+        return Integer.parseInt(multiplicator) * Integer.parseInt(pageLimit);
+    }
     public List<TriggerBE> findAllUnprocessed() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_UNPROCESSED);
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -268,31 +268,31 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAllWithPages(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = FIND_ALL_WITH_PAGES.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
+        String changedSQL = buildQuery(FIND_ALL_WITH_PAGES,pageLimit,actualOffset,actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findSuccessed(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = FIND_ALL_SUCCESSED.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
+        String changedSQL = buildQuery(FIND_ALL_SUCCESSED,pageLimit,actualOffset,actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findNews(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = FIND_ALL_NEWS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
+        String changedSQL = buildQuery(FIND_ALL_NEWS,pageLimit,actualOffset,actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findErrors(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = FIND_ALL_ERRORS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
+        String changedSQL = buildQuery(FIND_ALL_ERRORS,pageLimit,actualOffset,actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public List<TriggerBE> findInProgress(String multiplicator,String pageLimit,String dateInterval) {
         String actualDateInterval = changeTimestampToInterval(dateInterval);
         int actualOffset = calcOffset(multiplicator,pageLimit);
-        String changedSQL = FIND_ALL_IN_PROGRESS.replace("$limit$", pageLimit).replace("$offset$", Integer.toString(actualOffset)).replace("$dateInterval$", actualDateInterval);
+        String changedSQL = buildQuery(FIND_ALL_IN_PROGRESS,pageLimit,actualOffset,actualDateInterval);
         return basicDAO.selectEntityList(TRIGGER, changedSQL);
     }
     public void deleteEntries(String status, String dateInterval) {
@@ -369,7 +369,11 @@ public class TriggerDAO implements DataAccessObject {
         }
         return interval;
     }
-
+    private String buildQuery(String baseQuery, String pageLimit, int actualOffset, String dateInterval) {
+        return baseQuery.replace("$limit$", pageLimit)
+                .replace("$offset$", Integer.toString(actualOffset))
+                .replace("$dateInterval$", dateInterval);
+    }
     public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
         basicDAO.setCreationAttributes(triggerBE, currentUserId);
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAO.java
@@ -87,7 +87,6 @@ public class TriggerDAO implements DataAccessObject {
                     + "         where status != 4"
                     + SORTING
                     + " LIMIT 500";
-<<<<<<< #1591-Anpassung-Löschfunktion-vom-Protokoll-der-Datenmigration_EPIC_API_ENTPUNKT
     private static final String FIND_ALL_COUNT =
             selectCount
                             + " FROM altsystem_aenderung"
@@ -106,76 +105,6 @@ public class TriggerDAO implements DataAccessObject {
                             + "         AND st.status_name != 'SUCCESS'"
                             + "         where status != 4"
                             + " LIMIT 500";
-=======
-
-    private static final String FIND_ALL_WITH_PAGES =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
-                    + " ORDER BY altsystem_id"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_SUCCESSED =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 4"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
-                    + " ORDER BY altsystem_id"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_NEWS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 1"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
-                    + " ORDER BY altsystem_id"
-                    + " LIMIT $limit$ OFFSET $offset$";
-    private static final String FIND_ALL_IN_PROGRESS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 2"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
-                    + " ORDER BY altsystem_id"
-                    + " LIMIT $limit$ OFFSET $offset$";
-
-    private static final String FIND_ALL_ERRORS =
-            "SELECT * "
-                    + " FROM altsystem_aenderung"
-                    + "     LEFT JOIN altsystem_aenderung_operation op"
-                    + "         ON altsystem_aenderung.operation = op.operation_id"
-                    + "     LEFT JOIN altsystem_aenderung_status st"
-                    + "         ON altsystem_aenderung.status = st.status_id"
-                    + "         where status = 3"
-                    + "         AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'"
-                    + " ORDER BY altsystem_id"
-                    + " LIMIT $limit$ OFFSET $offset$";
-
-    private static final String DELETE_ENTRIES =
-            "START TRANSACTION; " +
-                    "DELETE FROM altsystem_aenderung " +
-                    "WHERE status = $status$ " +
-                    "AND created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
-                    "COMMIT;";
-    private static final String DELETE_ALL_ENTRIES =
-            "START TRANSACTION; " +
-                    "DELETE FROM altsystem_aenderung " +
-                    "WHERE created_at_utc >= CURRENT_DATE - INTERVAL '$dateInterval$'; " +
-                    "COMMIT;";
->>>>>>> develop
     private final BasicDAO basicDAO;
 
 
@@ -319,7 +248,6 @@ public class TriggerDAO implements DataAccessObject {
     public List<TriggerBE> findAllLimited() {
         return basicDAO.selectEntityList(TRIGGER, FIND_ALL_LIMITED);
     }
-<<<<<<< #1591-Anpassung-Löschfunktion-vom-Protokoll-der-Datenmigration_EPIC_API_ENTPUNKT
     public TriggerBE findAllCount(){ return basicDAO.selectSingleEntity(TRIGGER, FIND_ALL_COUNT);}
     public TriggerBE findUnprocessedCount(){
         return basicDAO.selectSingleEntity(TRIGGER, FIND_UNPROCESSED_COUNT);
@@ -336,16 +264,6 @@ public class TriggerDAO implements DataAccessObject {
         intervalMap.put("älter als sechs Monate", "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'");
 
         return intervalMap.getOrDefault(timestamp.replace("%20", " "), "");
-=======
-
-
-    public TriggerBE create(TriggerBE triggerBE, Long currentUserId) {
-        basicDAO.setCreationAttributes(triggerBE, currentUserId);
-
-        RawTriggerBE rawTrigger = resolveTrigger(triggerBE);
-        rawTrigger = basicDAO.insertEntity(RAW_TRIGGER, rawTrigger);
-        return resolveRawTrigger(rawTrigger);
->>>>>>> develop
     }
 
     public TriggerBE update(TriggerBE triggerBE, Long currentUserId) {

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
@@ -240,7 +240,7 @@ public class TriggerDAOTest {
 	@Test
 	public void testDeleteEntriesSuccess() {
 		// Call test method
-		triggerDAO.deleteEntries("Erfolgreich", "1 MONTH");
+		triggerDAO.deleteEntries("Erfolgreich", "letzter Monat");
 
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 4 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
@@ -249,7 +249,7 @@ public class TriggerDAOTest {
 	@Test
 	public void testDeleteEntriesNew() {
 		// Call test method
-		triggerDAO.deleteEntries("Neu", "1 MONTH");
+		triggerDAO.deleteEntries("Neu", "letzter Monat");
 
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 1 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
@@ -258,7 +258,7 @@ public class TriggerDAOTest {
 	@Test
 	public void testDeleteEntriesError() {
 		// Call test method
-		triggerDAO.deleteEntries("Fehlgeschlagen", "1 MONTH");
+		triggerDAO.deleteEntries("Fehlgeschlagen", "letzter Monat");
 
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 3 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
@@ -267,7 +267,7 @@ public class TriggerDAOTest {
 	@Test
 	public void testDeleteEntriesInProgress() {
 		// Call test method
-		triggerDAO.deleteEntries("Laufend", "1 MONTH");
+		triggerDAO.deleteEntries("Laufend", "letzter Monat");
 
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE status = 2 AND created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
@@ -276,7 +276,7 @@ public class TriggerDAOTest {
 	@Test
 	public void testDeleteEntriesAll() {
 		// Call test method
-		triggerDAO.deleteEntries("Alle", "1 MONTH");
+		triggerDAO.deleteEntries("Alle", "letzter Monat");
 
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerDAOTest.java
@@ -23,6 +23,7 @@ import static de.bogenliga.application.business.trigger.impl.business.TriggerCom
 import static de.bogenliga.application.business.trigger.impl.business.TriggerComponentImplTest.getTriggerBE;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -281,6 +282,40 @@ public class TriggerDAOTest {
 		// Verify that basicDAO.executeQuery was called with the correct SQL
 		String expectedSQL = "START TRANSACTION; DELETE FROM altsystem_aenderung WHERE created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'; COMMIT;";
 		verify(basicDAO).executeQuery(expectedSQL);
+	}
+	@Test
+	public void testChangeTimestampToDateInterval() {
+		String expectedValueForAll = "created_at_utc <= CURRENT_DATE";
+		String actualValueForAll = triggerDAO.changeTimestampToInterval("alle");
+		assertEquals(expectedValueForAll, actualValueForAll);
+
+		String expectedValueForOneMonth = "created_at_utc >= CURRENT_DATE - INTERVAL '1 MONTH'";
+		String actualValueForOneMonth = triggerDAO.changeTimestampToInterval("letzter Monat");
+		assertEquals(expectedValueForOneMonth, actualValueForOneMonth);
+
+		String expectedValueForLastThreeMonth = "created_at_utc >= CURRENT_DATE - INTERVAL '3 MONTH'";
+		String actualValueForLastThreeMonth = triggerDAO.changeTimestampToInterval("letzten drei Monate");
+		assertEquals(expectedValueForLastThreeMonth, actualValueForLastThreeMonth);
+
+		String expectedValueForLastSixMonth = "created_at_utc >= CURRENT_DATE - INTERVAL '6 MONTH'";
+		String actualValueForLastSixMonth = triggerDAO.changeTimestampToInterval("letzten sechs Monate");
+		assertEquals(expectedValueForLastSixMonth, actualValueForLastSixMonth);
+
+		String expectedValueForLastYear = "created_at_utc >= CURRENT_DATE - INTERVAL '12 MONTH'";
+		String actualValueForLastYear = triggerDAO.changeTimestampToInterval("im letzten Jahr");
+		assertEquals(expectedValueForLastYear, actualValueForLastYear);
+
+		String expectedValueForOlderThanOneMonth = "created_at_utc <= CURRENT_DATE - INTERVAL '1 MONTH'";
+		String actualValueForOlderThanOneMonth = triggerDAO.changeTimestampToInterval("älter als ein Monat");
+		assertEquals(expectedValueForOlderThanOneMonth, actualValueForOlderThanOneMonth);
+
+		String expectedValueForOlderThanThreeMonth = "created_at_utc <= CURRENT_DATE - INTERVAL '3 MONTH'";
+		String actualValueForOlderThanThreeMonth = triggerDAO.changeTimestampToInterval("älter als drei Monate");
+		assertEquals(expectedValueForOlderThanThreeMonth, actualValueForOlderThanThreeMonth);
+
+		String expectedValueForOlderThanSixMonth = "created_at_utc <= CURRENT_DATE - INTERVAL '6 MONTH'";
+		String actualValueForOlderThanSixMonth = triggerDAO.changeTimestampToInterval("älter als sechs Monate");
+		assertEquals(expectedValueForOlderThanSixMonth, actualValueForOlderThanSixMonth);
 	}
 }
 


### PR DESCRIPTION
Hinzufügen der Timestamp Filterfunktion für „älter als ein Monat“, „älter als drei Monate“, „älter als sechs Monate“ und Allgemeine Sortieränderung in den SQL Queries