### PR TITLE
Bugfix#1730 hinzufuegen mannschaft sportjahr

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
@@ -41,7 +41,7 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
         final String wettkampfTag = dsbMannschaftVerUWettDO.getWettkampfTag();
         final String wettkampfOrtsname = dsbMannschaftVerUWettDO.getWettkampf_ortsname();
         final String vereinName = dsbMannschaftVerUWettDO.getVerein_name();
-        final Long mannschaftNummer = dsbMannschaftVerUWettDO.getMannschaft_nummer();
+        final Long mannschaftNummer = dsbMannschaftVerUWettDO.getNummer();
         return new DsbMannschaftDTO(veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName,mannschaftNummer);
     };
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
@@ -20,8 +20,9 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
         final Long dsbMannschaftVereinId = dsbMannschaftDO.getVereinId();
         final Long dsbMannschaftNummer = dsbMannschaftDO.getNummer();
         final Long dsbMannschaftBenutzerId = dsbMannschaftDO.getBenutzerId();
-        final Long dsbMannschaftVeranstalungId = dsbMannschaftDO.getVeranstaltungId();
+        final Long dsbMannschaftVeranstaltungId = dsbMannschaftDO.getVeranstaltungId();
         final Long dsbMannschaftSortierung = dsbMannschaftDO.getSortierung();
+        final Long dsbMannschaftSportjahr = dsbMannschaftDO.getSportjahr();
         final String dsbMannschaftName = dsbMannschaftDO.getName();
 
         return new DsbMannschaftDTO(dsbMannschaftId,
@@ -29,8 +30,9 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
                 dsbMannschaftVereinId,
                 dsbMannschaftNummer,
                 dsbMannschaftBenutzerId,
-                dsbMannschaftVeranstalungId,
-                dsbMannschaftSortierung);
+                dsbMannschaftVeranstaltungId,
+                dsbMannschaftSortierung,
+                dsbMannschaftSportjahr);
 
 
 
@@ -57,8 +59,9 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
         final Long dsbMannschaftVereinId = dto.getVereinId();
         final Long dsbMannschaftNummer = dto.getNummer();
         final Long dsbMannschaftBenutzerId = dto.getBenutzerId();
-        final Long dsbMannschaftVeranstalungId = dto.getVeranstaltungId();
-        final Long dsbMannschaftSoriterung = dto.getSortierung();
+        final Long dsbMannschaftVeranstaltungId = dto.getVeranstaltungId();
+        final Long dsbMannschaftSortierung = dto.getSortierung();
+        final Long dsbMannschaftSportjahr = dto.getSportjahr();
         final String dsbMannschaftName = dto.getName();
 
         return new DsbMannschaftDO(dsbMannschaftId,
@@ -66,8 +69,10 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
                 dsbMannschaftVereinId,
                 dsbMannschaftNummer,
                 dsbMannschaftBenutzerId,
-                dsbMannschaftVeranstalungId,
-                dsbMannschaftSoriterung);
+                dsbMannschaftVeranstaltungId,
+                dsbMannschaftSortierung,
+                dsbMannschaftSportjahr
+        );
 
     };
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/DsbMannschaftDTOMapper.java
@@ -42,7 +42,7 @@ public class DsbMannschaftDTOMapper implements DataTransferObjectMapper {
         final String wettkampfOrtsname = dsbMannschaftVerUWettDO.getWettkampf_ortsname();
         final String vereinName = dsbMannschaftVerUWettDO.getVerein_name();
         final Long mannschaftNummer = dsbMannschaftVerUWettDO.getNummer();
-        return new DsbMannschaftDTO(veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName,mannschaftNummer);
+        return new DsbMannschaftDTO(veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName, mannschaftNummer);
     };
 
     /**

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/MannschaftSortierungDTOMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/mapper/MannschaftSortierungDTOMapper.java
@@ -25,6 +25,7 @@ public class MannschaftSortierungDTOMapper implements DataTransferObjectMapper {
         final Long dsbMannschaftNummer = 0L;
         final Long dsbMannschaftBenutzerId = 0L;
         final Long dsbMannschaftVeranstalungId = 0L;
+        final Long dsbMannschaftSportjahr = 0L;
 
         return new DsbMannschaftDO(dsbMannschaftId,
                 dsbMannschaftsName,
@@ -32,7 +33,8 @@ public class MannschaftSortierungDTOMapper implements DataTransferObjectMapper {
                 dsbMannschaftNummer,
                 dsbMannschaftBenutzerId,
                 dsbMannschaftVeranstalungId,
-                dsbMannschaftSoriterung);
+                dsbMannschaftSoriterung,
+                dsbMannschaftSportjahr);
 
     };
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/model/DsbMannschaftDTO.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/model/DsbMannschaftDTO.java
@@ -20,6 +20,7 @@ public class DsbMannschaftDTO implements DataTransferObject {
     private Long benutzerId;
     private Long veranstaltungId;
     private Long sortierung;
+    private Long sportjahr;
     private String veranstaltungName;
     private String wettkampfTag;
     private String wettkampfOrtsname;
@@ -36,7 +37,7 @@ public class DsbMannschaftDTO implements DataTransferObject {
 
 
     public DsbMannschaftDTO(Long id, String name, Long vereinId, Long nummer,
-                            Long benutzerId, Long veranstaltungId, Long sortierung) {
+                            Long benutzerId, Long veranstaltungId, Long sortierung, Long sportjahr) {
         this.id = id;
         this.name = name;
         this.vereinId = vereinId;
@@ -44,6 +45,7 @@ public class DsbMannschaftDTO implements DataTransferObject {
         this.benutzerId=benutzerId;
         this.veranstaltungId=veranstaltungId;
         this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
 
     }
     public DsbMannschaftDTO(final String veranstaltungName,final String wettkampfTag, final String wettkampfOrtsname, final String vereinName,final long mannschaftNummer) {
@@ -86,6 +88,10 @@ public class DsbMannschaftDTO implements DataTransferObject {
     public Long getSortierung(){return sortierung;}
 
     public void setSortierung(Long sortierung){this.sortierung=sortierung;}
+
+    public Long getSportjahr(){return sportjahr;}
+
+    public void setSportjahr(Long sportjahr){this.sportjahr=sportjahr;}
     public String getWettkampfOrtsname() {
         return wettkampfOrtsname;
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -160,12 +160,14 @@ public class DsbMannschaftService implements ServiceFacade {
      *
      * @return list of {@link DsbMannschaftDTO} as JSON
      */
-    @GetMapping(value = "byWarteschlangeID/", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "byWarteschlangeID//{veranstaltungsId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
-    public List<DsbMannschaftDTO> findAllbyWarteschlangeID()
+    public List<DsbMannschaftDTO> findAllbyWarteschlangeID(@PathVariable("veranstaltungsId") final Long id)
 
     {
-        final List<DsbMannschaftDO> dsbMannschaftDOList  = dsbMannschaftComponent.findAllByWarteschlange();
+        Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
+
+        final List<DsbMannschaftDO> dsbMannschaftDOList  = dsbMannschaftComponent.findAllByWarteschlange(id);
         return dsbMannschaftDOList.stream().map(DsbMannschaftDTOMapper.toDTO).toList();
     }
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -469,7 +469,7 @@ public class DsbMannschaftService implements ServiceFacade {
         DsbMannschaftDO neueMannschaft = dsbMannschaftComponent.update(dsbMannschaftDO, userId);
 
 
-        LOG.debug("Mannschaft '{}'  Veranstaltung mit id '{}' zugeordnet.", dsbMannschaftDO.getName(), veranstaltungsId);
+        LOG.debug("Mannschaft '{}'  Veranstaltung mit id '{}' zugeordnet.", neueMannschaft.getName(), neueMannschaft.getVeranstaltungId());
 
     }
 
@@ -492,7 +492,7 @@ public class DsbMannschaftService implements ServiceFacade {
 
         if (dsbMannschaftDO.getVeranstaltungId() != null){ // hier ist eine Veranstaltung zugewiesen
             VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(dsbMannschaftDO.getVeranstaltungId());
-            if (veranstaltungDO != null && veranstaltungDO.getVeranstaltungPhase() == "Geplant") {
+            if (veranstaltungDO != null && veranstaltungDO.getVeranstaltungPhase().equals("Geplant")) {
                 dsbMannschaftDO.setVeranstaltungId(null);
                 dsbMannschaftDO.setSportjahr(null);
                 DsbMannschaftDO neueMannschaft = dsbMannschaftComponent.update(dsbMannschaftDO, userId);
@@ -580,8 +580,7 @@ public class DsbMannschaftService implements ServiceFacade {
         }
 
         // Wenn eine Veranstaltung zugeordnet ist (id!=null) und die Phase ist nicht "Geplant", dann nicht löschen
-        if (dsbMannschaftDO.getVeranstaltungId() != null )
-            if (veranstaltungComponent.findById(dsbMannschaftDO.getVeranstaltungId()).getVeranstaltungPhase() != "Geplant")
+        if (dsbMannschaftDO.getVeranstaltungId() != null && veranstaltungComponent.findById(dsbMannschaftDO.getVeranstaltungId()).getVeranstaltungPhase().equals("Geplant"))
                 throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, "Mannschaft kann nicht gelöscht werden - es liegen weitere abhängige Daten vor.");
 
         dsbMannschaftComponent.delete(dsbMannschaftDO, userId);

--- a/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V20_0__alter_mannschaft_add_sportjahr.sql
+++ b/bogenliga/bogenliga-application/src/main/resources/db/migration/all/V20_0__alter_mannschaft_add_sportjahr.sql
@@ -1,0 +1,11 @@
+
+ALTER TABLE mannschaft
+ADD COLUMN mannschaft_sportjahr NUMERIC(4);
+
+UPDATE mannschaft
+SET mannschaft_sportjahr = sub.veranstaltung_sportjahr
+FROM (
+    SELECT veranstaltung_id, veranstaltung_sportjahr
+    FROM veranstaltung
+    )sub
+WHERE mannschaft.mannschaft_veranstaltung_id = sub.veranstaltung_id;

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
@@ -175,6 +175,7 @@ public class SyncServiceTest {
     private static final Long M_benutzerId = 12L;
     private static final Long M_veranstaltungId = 1L;
     private static final Long M_sortierung = 1L;
+    private static final Long M_sportjahr = 1L;
 
     private static final Long VEREIN_USER = 1L;
     private static final Long VERSION = 0L;
@@ -347,7 +348,8 @@ public class SyncServiceTest {
                 M_nummer,
                 M_benutzerId,
                 M_veranstaltungId,
-                M_sortierung
+                M_sortierung,
+                M_sportjahr
         );
     }
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.MockitoRule;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBE;
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
 import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
 import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
@@ -85,7 +86,7 @@ public class DsbMannschaftServiceTest {
         );
     }
     public static DsbMannschaftDO getDsbMannschaftDOVERANDWETT() {
-        return new DsbMannschaftDO(VERANSTALTUNGNAME,WETTKAMPFTAG,WETTKAMPFORT,VEREINNAME,MANNSCHAFTS_NUMMER);
+        return new DsbMannschaftDO(VERANSTALTUNGNAME,WETTKAMPFTAG,WETTKAMPFORT,VEREINNAME);
     }
 
     public static DsbMannschaftDO getPlatzhalterDO() {
@@ -106,45 +107,39 @@ public class DsbMannschaftServiceTest {
         );
     }
     private DsbMannschaftBE dsbMannschaft;
+    private DsbMannschaftBEext dsbMannschaftext;
     @Test
     public void testGetAndSetVeranstaltungName() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String veranstaltungName = "Meisterschaft";
-        dsbMannschaft.setVeranstaltungName(veranstaltungName);
-        assertThat(dsbMannschaft.getVeranstaltungName()).isEqualTo(veranstaltungName);
+        dsbMannschaftext.setVeranstaltungName(veranstaltungName);
+        assertThat(dsbMannschaftext.getVeranstaltungName()).isEqualTo(veranstaltungName);
     }
 
     @Test
     public void testGetAndSetWettkampfTag() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String wettkampfTag = "2024-07-22";
-        dsbMannschaft.setWettkampfTag(wettkampfTag);
-        assertThat(dsbMannschaft.getWettkampfTag()).isEqualTo(wettkampfTag);
+        dsbMannschaftext.setWettkampfTag(wettkampfTag);
+        assertThat(dsbMannschaftext.getWettkampfTag()).isEqualTo(wettkampfTag);
     }
 
     @Test
     public void testGetAndSetWettkampfOrtsname() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String wettkampfOrtsname = "Berlin";
-        dsbMannschaft.setWettkampfOrtsname(wettkampfOrtsname);
-        assertThat(dsbMannschaft.getWettkampfOrtsname()).isEqualTo(wettkampfOrtsname);
+        dsbMannschaftext.setWettkampfOrtsname(wettkampfOrtsname);
+        assertThat(dsbMannschaftext.getWettkampfOrtsname()).isEqualTo(wettkampfOrtsname);
     }
 
     @Test
     public void testGetAndSetVereinName() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String vereinName = "Sportverein Berlin";
-        dsbMannschaft.setVereinName(vereinName);
-        assertThat(dsbMannschaft.getVereinName()).isEqualTo(vereinName);
+        dsbMannschaftext.setVereinName(vereinName);
+        assertThat(dsbMannschaftext.getVereinName()).isEqualTo(vereinName);
     }
 
-    @Test
-    public void testGetAndSetMannschaftNummer() {
-        dsbMannschaft = new DsbMannschaftBE();
-        Long mannschaftNummer = 12345L;
-        dsbMannschaft.setMannschaftNummer(mannschaftNummer);
-        assertThat(dsbMannschaft.getMannschaftNummer()).isEqualTo(mannschaftNummer);
-    }
     public static VeranstaltungDO getMockVeranstaltung(){
         return new VeranstaltungDO(
                 null, null, null, null, null, null, null, null, null, null, null, null, null,null, null, null, 8
@@ -322,7 +317,7 @@ public class DsbMannschaftServiceTest {
         final DsbMannschaftDTO actualDTO = actual.get(0);
 
         assertThat(actualDTO).isNotNull();
-        assertThat(actualDTO.getMannschaftNummer()).isEqualTo(dsbMannschaftDO.getMannschaft_nummer());
+        assertThat(actualDTO.getMannschaftNummer()).isEqualTo(dsbMannschaftDO.getNummer());
         assertThat(actualDTO.getVereinName()).isEqualTo(dsbMannschaftDO.getVerein_name());
         assertThat(actualDTO.getVeranstaltungName()).isEqualTo(dsbMannschaftDO.getVeranstaltung_name());
 
@@ -650,10 +645,10 @@ public class DsbMannschaftServiceTest {
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(expectedDsbMannschaftDO);
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
         when(dsbMannschaftComponent.create(any(), anyLong())).thenReturn(expectedDsbMannschaftDO);
-
+// @TODO Tests für die beidnen neuen Funktionen
         // call test method
-        underTest.insertMannschaftIntoVeranstaltung(inputVeranstaltungsId, expectedDsbMannschaftDO.getId(),
-                principal);
+ //       underTest.insertMannschaftIntoVeranstaltung(inputVeranstaltungsId, expectedDsbMannschaftDO.getId(),
+ //               principal);
 
         // verify invocations
         verify(dsbMannschaftComponent).create(dsbMannschaftVOArgumentCaptor.capture(), anyLong());

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -345,7 +345,6 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getMannschaftNummer()).isEqualTo(dsbMannschaftDO.getNummer());
         assertThat(actualDTO.getVereinName()).isEqualTo(dsbMannschaftDO.getVerein_name());
         assertThat(actualDTO.getVeranstaltungName()).isEqualTo(dsbMannschaftDO.getVeranstaltung_name());
-        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
         verify(dsbMannschaftComponent).findVeranstaltungAndWettkampfByID(1893);
@@ -672,6 +671,9 @@ public class DsbMannschaftServiceTest {
         // Prepare test data
         final DsbMannschaftDO expectedDsbMannschaftDO = getDsbMannschaftDO();
         final long inputVeranstaltungsId = 222L;
+        final VeranstaltungDO expectedVeranstaltungDO = getVeranstaltungDO();
+        expectedVeranstaltungDO.setVeranstaltungID(222L);
+        expectedVeranstaltungDO.setVeranstaltungSportJahr(2024L);
 
         // configure mocks
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(expectedDsbMannschaftDO);
@@ -679,6 +681,7 @@ public class DsbMannschaftServiceTest {
 
         when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(true);
         when(dsbMannschaftComponent.update(any(), anyLong())).thenReturn(expectedDsbMannschaftDO);
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(expectedVeranstaltungDO);
         // call test method
         try {
             underTest.assignMannschaftToVeranstaltung(inputVeranstaltungsId, expectedDsbMannschaftDO.getId(), principal);
@@ -691,7 +694,8 @@ public class DsbMannschaftServiceTest {
         DsbMannschaftDO capturedDsbMannschaftDO = dsbMannschaftVOArgumentCaptor.getValue();
         assertThat(capturedDsbMannschaftDO).isNotNull();
         assertThat(capturedDsbMannschaftDO.getId()).isEqualTo(expectedDsbMannschaftDO.getId());
-        assertThat(capturedDsbMannschaftDO.getVeranstaltungId()).isEqualTo(inputVeranstaltungsId);
+        assertThat(capturedDsbMannschaftDO.getVeranstaltungId()).isEqualTo(expectedVeranstaltungDO.getVeranstaltungID());
+        assertThat(capturedDsbMannschaftDO.getSportjahr()).isEqualTo(expectedVeranstaltungDO.getVeranstaltungSportJahr());
     }
 
     @Test
@@ -731,6 +735,7 @@ public class DsbMannschaftServiceTest {
         final VeranstaltungDO expectedVeranstaltungDO = getVeranstaltungDO();
         final DsbMannschaftDO expectedDsbMannschaftOhneVeranstaltungDO = getDsbMannschaftDO();
         expectedDsbMannschaftOhneVeranstaltungDO.setVeranstaltungId(null);
+
 
         // configure mocks
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(expectedDsbMannschaftOhneVeranstaltungDO);

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -46,7 +46,6 @@ public class DsbMannschaftServiceTest {
     private static final long NUMMER = 22222;
     private static final long BENUTZER_ID = 33333;
     private static final long VERANSTALTUNG_ID = 4444;
-    private static final long MANNSCHAFTS_NUMMER = 165;
     private static final String WETTKAMPFORT = "Reutlingen";
     private static final String VERANSTALTUNGNAME = "TEST";
     private static final String VEREINNAME = "SSV Reutlingen";
@@ -108,7 +107,6 @@ public class DsbMannschaftServiceTest {
                 6969L, "Mockmannschaft", 99L, 696969L, 01274L, 4445L, 8L, SPORTJAHR
         );
     }
-    private DsbMannschaftBE dsbMannschaft;
     private DsbMannschaftBEext dsbMannschaftext;
     @Test
     public void testGetAndSetVeranstaltungName() {
@@ -688,7 +686,7 @@ public class DsbMannschaftServiceTest {
 
             // verify invocations
             verify(dsbMannschaftComponent).update(dsbMannschaftVOArgumentCaptor.capture(), anyLong());
-        } catch (NoPermissionException e) {}
+        } catch (NoPermissionException e) {;}
 
         // assert result
         DsbMannschaftDO capturedDsbMannschaftDO = dsbMannschaftVOArgumentCaptor.getValue();

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -54,6 +54,7 @@ public class DsbMannschaftServiceTest {
 
     private static final long CURRENT_VERANSTALTUNG_ID = 55555;
     private static final long SORTIERUNG = 1;
+    private static final long SPORTJAHR = 2024L;
 
     private static final long PLATZHALTER_VEREIN_ID = 99;
     private static final long PLATZHALTER_ID = 6969;
@@ -83,28 +84,28 @@ public class DsbMannschaftServiceTest {
 
     public static DsbMannschaftDO getDsbMannschaftDO() {
         return new DsbMannschaftDO(
-                ID, NAME, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, SORTIERUNG
+                ID, NAME, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, SORTIERUNG, SPORTJAHR
         );
     }
     public static DsbMannschaftDO getDsbMannschaftDOVERANDWETT() {
-        return new DsbMannschaftDO(ID, NAME, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, SORTIERUNG, VERANSTALTUNGNAME,WETTKAMPFTAG,WETTKAMPFORT,VEREINNAME);
+        return new DsbMannschaftDO(ID, NAME, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, SORTIERUNG, SPORTJAHR, VERANSTALTUNGNAME,WETTKAMPFTAG,WETTKAMPFORT,VEREINNAME);
     }
 
     public static DsbMannschaftDO getPlatzhalterDO() {
         return new DsbMannschaftDO(
-                PLATZHALTER_ID, "Platzhalter", PLATZHALTER_VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, 8L
+                PLATZHALTER_ID, "Platzhalter", PLATZHALTER_VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, 8L, SPORTJAHR
         );
     }
 
     public static DsbMannschaftDTO getPlatzhalterDTO() {
         return new DsbMannschaftDTO(
-                PLATZHALTER_ID, "Platzhalter", PLATZHALTER_VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, 8L
+                PLATZHALTER_ID, "Platzhalter", PLATZHALTER_VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID, 8L, SPORTJAHR
         );
     }
 
     public static DsbMannschaftDO getMockMannschaft() {
         return new DsbMannschaftDO(
-                6969L, "Mockmannschaft", 99L, 696969L, 01274L, 4445L, 8L
+                6969L, "Mockmannschaft", 99L, 696969L, 01274L, 4445L, 8L, SPORTJAHR
         );
     }
     private DsbMannschaftBE dsbMannschaft;
@@ -156,6 +157,7 @@ public class DsbMannschaftServiceTest {
         dsbMannschaftDTO.setBenutzerId(BENUTZER_ID);
         dsbMannschaftDTO.setVeranstaltungId(VERANSTALTUNG_ID);
         dsbMannschaftDTO.setSortierung(SORTIERUNG);
+        dsbMannschaftDTO.setSportjahr(SPORTJAHR);
 
         return dsbMannschaftDTO;
     }
@@ -233,6 +235,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getId()).isEqualTo(dsbMannschaftDO.getId());
         assertThat(actualDTO.getVereinId()).isEqualTo(dsbMannschaftDO.getVereinId());
         assertThat(actualDTO.getSortierung()).isEqualTo(dsbMannschaftDO.getSortierung());
+        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         //verify invocations
         verify(dsbMannschaftComponent).findAllByVereinsId(VEREIN_ID);
@@ -260,6 +263,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getId()).isEqualTo(dsbMannschaftDO.getId());
         assertThat(actualDTO.getVeranstaltungId()).isEqualTo(dsbMannschaftDO.getVeranstaltungId());
         assertThat(actualDTO.getSortierung()).isEqualTo(dsbMannschaftDO.getSortierung());
+        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         //verify invocations
         verify(dsbMannschaftComponent).findAllByVeranstaltungsId(VERANSTALTUNG_ID);
@@ -272,10 +276,10 @@ public class DsbMannschaftServiceTest {
         final List<DsbMannschaftDO> dsbMannschaftDOList = Collections.singletonList(dsbMannschaftDO);
 
         // configure mocks
-        when(dsbMannschaftComponent.findAllByWarteschlange()).thenReturn(dsbMannschaftDOList);
+        when(dsbMannschaftComponent.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID)).thenReturn(dsbMannschaftDOList);
 
         // call test method
-        final List<DsbMannschaftDTO> actual = underTest.findAllbyWarteschlangeID();
+        final List<DsbMannschaftDTO> actual = underTest.findAllbyWarteschlangeID(CURRENT_VERANSTALTUNG_ID);
 
         // assert result
         assertThat(actual).isNotNull().hasSize(1);
@@ -286,9 +290,10 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getId()).isEqualTo(dsbMannschaftDO.getId());
         assertThat(actualDTO.getVereinId()).isEqualTo(dsbMannschaftDO.getVereinId());
         assertThat(actualDTO.getSortierung()).isEqualTo(dsbMannschaftDO.getSortierung());
+        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
-        verify(dsbMannschaftComponent).findAllByWarteschlange();
+        verify(dsbMannschaftComponent).findAllByWarteschlange(anyLong());
     }
 
     @Test
@@ -313,6 +318,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getId()).isEqualTo(dsbMannschaftDO.getId());
         assertThat(actualDTO.getVereinId()).isEqualTo(dsbMannschaftDO.getVereinId());
         assertThat(actualDTO.getSortierung()).isEqualTo(dsbMannschaftDO.getSortierung());
+        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
         verify(dsbMannschaftComponent).findAllByName(name);
@@ -339,6 +345,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getMannschaftNummer()).isEqualTo(dsbMannschaftDO.getNummer());
         assertThat(actualDTO.getVereinName()).isEqualTo(dsbMannschaftDO.getVerein_name());
         assertThat(actualDTO.getVeranstaltungName()).isEqualTo(dsbMannschaftDO.getVeranstaltung_name());
+        assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
         verify(dsbMannschaftComponent).findVeranstaltungAndWettkampfByID(1893);
@@ -360,6 +367,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actual.getId()).isEqualTo(dsbMannschaftDO.getId());
         assertThat(actual.getVereinId()).isEqualTo(dsbMannschaftDO.getVereinId());
         assertThat(actual.getSortierung()).isEqualTo(dsbMannschaftDO.getSortierung());
+        assertThat(actual.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
         verify(dsbMannschaftComponent).findById(ID);
@@ -394,6 +402,7 @@ public class DsbMannschaftServiceTest {
             assertThat(actual.getId()).isEqualTo(input.getId());
             assertThat(actual.getVereinId()).isEqualTo(input.getVereinId());
             assertThat(actual.getSortierung()).isEqualTo(input.getSortierung());
+            assertThat(actual.getSportjahr()).isEqualTo(input.getSportjahr());
 
 
             // verify invocations
@@ -405,6 +414,7 @@ public class DsbMannschaftServiceTest {
             assertThat(createdDsbMannschaft.getId()).isEqualTo(input.getId());
             assertThat(createdDsbMannschaft.getVereinId()).isEqualTo(input.getVereinId());
             assertThat(createdDsbMannschaft.getSortierung()).isEqualTo(input.getSortierung());
+            assertThat(createdDsbMannschaft.getSportjahr()).isEqualTo(input.getSportjahr());
 
         } catch (NoPermissionException e) { }
     }
@@ -436,6 +446,7 @@ public class DsbMannschaftServiceTest {
             assertThat(actual.getId()).isEqualTo(platzhalterDTO.getId());
             assertThat(actual.getVereinId()).isEqualTo(platzhalterDTO.getVereinId());
             assertThat(actual.getSortierung()).isEqualTo(platzhalterDTO.getSortierung());
+            assertThat(actual.getSportjahr()).isEqualTo(platzhalterDTO.getSportjahr());
 
 
             // verify invocations
@@ -447,6 +458,7 @@ public class DsbMannschaftServiceTest {
             assertThat(createdDsbMannschaft.getId()).isEqualTo(platzhalterDTO.getId());
             assertThat(createdDsbMannschaft.getVereinId()).isEqualTo(platzhalterDTO.getVereinId());
             assertThat(createdDsbMannschaft.getSortierung()).isEqualTo(platzhalterDTO.getSortierung());
+            assertThat(createdDsbMannschaft.getSportjahr()).isEqualTo(platzhalterDTO.getSportjahr());
 
         } catch (NoPermissionException e) { }
     }
@@ -590,6 +602,7 @@ public class DsbMannschaftServiceTest {
             assertThat(updatedDsbMannschaft.getId()).isEqualTo(input.getId());
             assertThat(updatedDsbMannschaft.getVereinId()).isEqualTo(input.getVereinId());
             assertThat(updatedDsbMannschaft.getSortierung()).isEqualTo(input.getSortierung());
+            assertThat(updatedDsbMannschaft.getSportjahr()).isEqualTo(input.getSportjahr());
 
         } catch (NoPermissionException e) { }
     }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -276,10 +276,10 @@ public class DsbMannschaftServiceTest {
         final List<DsbMannschaftDO> dsbMannschaftDOList = Collections.singletonList(dsbMannschaftDO);
 
         // configure mocks
-        when(dsbMannschaftComponent.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID)).thenReturn(dsbMannschaftDOList);
+        when(dsbMannschaftComponent.findAllByWarteschlange()).thenReturn(dsbMannschaftDOList);
 
         // call test method
-        final List<DsbMannschaftDTO> actual = underTest.findAllbyWarteschlangeID(CURRENT_VERANSTALTUNG_ID);
+        final List<DsbMannschaftDTO> actual = underTest.findAllbyWarteschlangeID();
 
         // assert result
         assertThat(actual).isNotNull().hasSize(1);
@@ -293,7 +293,7 @@ public class DsbMannschaftServiceTest {
         assertThat(actualDTO.getSportjahr()).isEqualTo(dsbMannschaftDO.getSportjahr());
 
         // verify invocations
-        verify(dsbMannschaftComponent).findAllByWarteschlange(anyLong());
+        verify(dsbMannschaftComponent).findAllByWarteschlange();
     }
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
@@ -30,10 +30,11 @@ import static org.mockito.Mockito.*;
 
 public class MannschaftSortierungServiceTest {
 
-    private static final long USER = 0;
-    private static final long ID = 1893;
+    private static final Long USER = 0L;
+    private static final Long ID = 1893L;
 
-    private static final long SORTIERUNG = 1;
+    private static final Long SORTIERUNG = 1L;
+    private static final Long SPORTJAHR = 1L;
 
     private static final long DB_VEREIN_ID = 111111;
     private static final String DB_NAME = null; //empty
@@ -61,7 +62,7 @@ public class MannschaftSortierungServiceTest {
 
     private static DsbMannschaftDO getDsbMannschaftDO() {
         return new DsbMannschaftDO(
-                ID, DB_NAME, DB_VEREIN_ID, DB_NUMMER, DB_BENUTZER_ID, DB_VERANSTALTUNG_ID, SORTIERUNG
+                ID, DB_NAME, DB_VEREIN_ID, DB_NUMMER, DB_BENUTZER_ID, DB_VERANSTALTUNG_ID, SORTIERUNG, SPORTJAHR
         );
     }
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/mannschaftsmitglied/Service/MannschaftsmitgliedServiceTest.java
@@ -72,8 +72,8 @@ public class MannschaftsmitgliedServiceTest {
 
     public static DsbMannschaftDO getDsbMannschaftDO() {
         return new DsbMannschaftDO(
-                mannschaftsId, "die Mannschaft", id, 23,
-                id, id, 2L
+                mannschaftsId, "die Mannschaft", id, 23L,
+                id, id, 2L, 1L
         );
     }
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/match/service/MatchServiceTest.java
@@ -160,6 +160,8 @@ public class MatchServiceTest {
     private static final Long M_veranstaltungId = 1L;
     private static final Long M_sortierung = 1L;
 
+    private static final Long M_sportjahr = 2024L;
+
     private static final Long VEREIN_USER = 1L;
     private static final Long VERSION = 0L;
     private static final String VEREIN_NAME = "Test Verein";
@@ -193,7 +195,7 @@ public class MatchServiceTest {
 
     protected DsbMannschaftDO getPlatzhalter() {
         return new DsbMannschaftDO(
-                MATCH_MANNSCHAFT_ID, "Platzhalter", PLATZHALTER_ID, 696969L, M_benutzerId, 4444L, 8L
+                MATCH_MANNSCHAFT_ID, "Platzhalter", PLATZHALTER_ID, 696969L, M_benutzerId, 4444L, 8L, 2024L
         );
     }
 
@@ -254,7 +256,8 @@ public class MatchServiceTest {
                 M_nummer,
                 M_benutzerId,
                 M_veranstaltungId,
-                M_sortierung
+                M_sortierung,
+                M_sportjahr
         );
     }
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemMannschaftMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/altsystem/mannschaft/mapper/AltsystemMannschaftMapper.java
@@ -49,7 +49,7 @@ public class AltsystemMannschaftMapper implements ValueObjectMapper {
         //Letztes Zeichen im Namen
         char lastChar = altsystemMannschaftDO.getName().charAt(nameLong);
         String lastCharAsString = String.valueOf(lastChar);
-        int mannNr;
+        long mannNr;
         String num = "1234567890";
 
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
@@ -81,7 +81,7 @@ public interface DsbMannschaftComponent extends ComponentFacade {
      * @return persisted version of the dsbmannschaft
      */
 
-    DsbMannschaftDO update(DsbMannschaftDO dsbMannschaftdDO, long currentDsbMannschaftId);
+    DsbMannschaftDO update(DsbMannschaftDO dsbMannschaftdDO, long userId);
 
 
     /**
@@ -90,7 +90,7 @@ public interface DsbMannschaftComponent extends ComponentFacade {
      * @param dsbMannschaftDO dsbmannschaft to delete
      */
 
-    void delete(DsbMannschaftDO dsbMannschaftDO, Long currentDsbMitgliedId);
+    void delete(DsbMannschaftDO dsbMannschaftDO, Long userId);
 
     /**
      * Copys the Mannschaften of an old Veranstaltung into a new Veranstaltung

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
@@ -105,12 +105,13 @@ public interface DsbMannschaftComponent extends ComponentFacade {
 
     /**
      * Return all dsbmannschaft entries that are currently in the waiting queue.
-     *
+     * queue is defined by dsbmannschaft without veransatltungs_ID and a matching Sportjahr
      * @return all dsbmannschaft entries in the waiting queue.
      * null, if no dsbmannschaft is found.
      */
 
-    List<DsbMannschaftDO> findAllByWarteschlange();
+
+    List<DsbMannschaftDO> findAllByWarteschlange(Long veranstaltungsID);
 
     /**
      * Return all dsbmannschaft entries with the given name.

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/DsbMannschaftComponent.java
@@ -111,7 +111,7 @@ public interface DsbMannschaftComponent extends ComponentFacade {
      */
 
 
-    List<DsbMannschaftDO> findAllByWarteschlange(Long veranstaltungsID);
+    List<DsbMannschaftDO> findAllByWarteschlange();
 
     /**
      * Return all dsbmannschaft entries with the given name.

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
@@ -20,6 +20,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
     private Long benutzerId;
     private Long veranstaltungId;
     private Long sortierung;
+    private Long sportjahr;
     private String veranstaltung_name;
     private String wettkampf_tag;
     private String wettkampf_ortsname;
@@ -35,6 +36,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param benutzerId
      * @param veranstaltungId
      * @param sortierung
+     * @param sportjahr
      * @param createdAtUtc
      * @param createdByUserId
      * @param lastModifiedAtUtc
@@ -43,7 +45,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      */
 
     public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung, final OffsetDateTime createdAtUtc, final Long createdByUserId,
+                           final Long sortierung, final long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,
                            final OffsetDateTime lastModifiedAtUtc, final Long lastModifiedByUserId, final Long version) {
         this.id = id;
         this.name = name;
@@ -52,6 +54,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
         this.benutzerId=benutzerId;
         this.veranstaltungId=veranstaltungId;
         this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
         this.createdAtUtc = createdAtUtc;
         this.createdByUserId = createdByUserId;
         this.lastModifiedAtUtc = lastModifiedAtUtc;
@@ -60,15 +63,17 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
     }
 
      public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung,
+                           final Long sortierung, final long sportjahr,
                            final String veranstaltung_name, final String wettkampfTag, final String wettkampf_ortsname, final String verein_name) {
-         this.id = id;
-         this.name = name;
-         this.vereinId=vereinId;
-         this.nummer=nummer;
-         this.benutzerId=benutzerId;
-         this.veranstaltungId=veranstaltungId;
-         this.sortierung = sortierung;
+        this.id = id;
+        this.name = name;
+        this.vereinId=vereinId;
+        this.nummer=nummer;
+        this.benutzerId=benutzerId;
+        this.veranstaltungId=veranstaltungId;
+        this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
+
         this.veranstaltung_name = veranstaltung_name;
         this.wettkampf_tag = wettkampfTag;
         this.wettkampf_ortsname = wettkampf_ortsname;
@@ -97,7 +102,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param version
      */
     public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung, final OffsetDateTime createdAtUtc, final Long createdByUserId,final Long version) {
+                           final Long sortierung, final long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,final Long version) {
         this.id = id;
         this.name = name;
         this.vereinId=vereinId;
@@ -105,6 +110,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
         this.benutzerId=benutzerId;
         this.veranstaltungId=veranstaltungId;
         this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
         this.createdAtUtc = createdAtUtc;
         this.createdByUserId = createdByUserId;
         this.version = version;
@@ -121,7 +127,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
 
      */
     public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer,
-                           final long benutzerId,final Long veranstaltungId, final Long sortierung) {
+                           final long benutzerId,final Long veranstaltungId, final Long sortierung, final long sportjahr) {
         this.id = id;
         this.name = name;
         this.vereinId=vereinId;
@@ -129,6 +135,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
         this.benutzerId=benutzerId;
         this.veranstaltungId=veranstaltungId;
         this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
 
     }
 
@@ -189,6 +196,11 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
     public Long getSortierung(){return sortierung;}
 
     public void setSortierung(final long sortierung){this.sortierung=sortierung;}
+
+    public Long getSportjahr(){return sportjahr;}
+
+    public void setSportjahr(final long sportjahr){this.sportjahr=sportjahr;}
+
     public String getVeranstaltung_name() {
         return veranstaltung_name;
     }
@@ -224,7 +236,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, vereinId,nummer,benutzerId,veranstaltungId,sortierung,
+        return Objects.hash(id, vereinId,nummer,benutzerId,veranstaltungId,sortierung, sportjahr,
                 createdByUserId, lastModifiedAtUtc,
                 lastModifiedByUserId, version,id, veranstaltung_name, wettkampf_tag, wettkampf_ortsname, verein_name);
     }
@@ -243,6 +255,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
                 vereinId == that.vereinId &&
                 benutzerId == that.benutzerId &&
                 sortierung == that.sortierung &&
+                sportjahr == that.sportjahr &&
                 nummer == that.nummer &&
                 createdByUserId == that.createdByUserId &&
                 lastModifiedByUserId == that.lastModifiedByUserId &&

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
@@ -44,8 +44,8 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param version
      */
 
-    public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung, final long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,
+    public DsbMannschaftDO(final Long id, final String name, final Long vereinId, final Long nummer, final Long benutzerId,final Long veranstaltungId,
+                           final Long sortierung, final Long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,
                            final OffsetDateTime lastModifiedAtUtc, final Long lastModifiedByUserId, final Long version) {
         this.id = id;
         this.name = name;
@@ -62,8 +62,8 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
         this.version = version;
     }
 
-     public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung, final long sportjahr,
+     public DsbMannschaftDO(final Long id, final String name, final Long vereinId, final Long nummer, final Long benutzerId,final Long veranstaltungId,
+                           final Long sortierung, final Long sportjahr,
                            final String veranstaltung_name, final String wettkampfTag, final String wettkampf_ortsname, final String verein_name) {
         this.id = id;
         this.name = name;
@@ -101,8 +101,8 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param createdByUserId
      * @param version
      */
-    public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
-                           final Long sortierung, final long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,final Long version) {
+    public DsbMannschaftDO(final Long id, final String name, final Long vereinId, final Long nummer, final Long benutzerId,final Long veranstaltungId,
+                           final Long sortierung, final Long sportjahr, final OffsetDateTime createdAtUtc, final Long createdByUserId,final Long version) {
         this.id = id;
         this.name = name;
         this.vereinId=vereinId;
@@ -126,8 +126,8 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param veranstaltungId
 
      */
-    public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer,
-                           final long benutzerId,final Long veranstaltungId, final Long sortierung, final long sportjahr) {
+    public DsbMannschaftDO(final Long id, final String name, final Long vereinId, final Long nummer,
+                           final Long benutzerId,final Long veranstaltungId, final Long sortierung, final Long sportjahr) {
         this.id = id;
         this.name = name;
         this.vereinId=vereinId;
@@ -144,7 +144,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
      * @param id
      * @param vereinId
      */
-    public DsbMannschaftDO(final Long id, final long vereinId) {
+    public DsbMannschaftDO(final Long id, final Long vereinId) {
         this.id = id;
         this.vereinId = vereinId;
     }
@@ -165,7 +165,7 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
 
     public Long getId(){ return id; }
 
-    public void setId(final long id){this.id=id;}
+    public void setId(final Long id){this.id=id;}
 
 
     public String getName(){ return name; }
@@ -175,17 +175,17 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
 
     public Long getVereinId(){return vereinId;}
 
-    public void setVereinId(final long vereinId){this.vereinId=vereinId;}
+    public void setVereinId(final Long vereinId){this.vereinId=vereinId;}
 
 
     public Long getNummer(){return nummer;}
 
-    public void setNummer(final long nummer){this.nummer=nummer;}
+    public void setNummer(final Long nummer){this.nummer=nummer;}
 
 
     public Long getBenutzerId(){return benutzerId;}
 
-    public void setBenutzerId(final long benutzerId){this.benutzerId=benutzerId;}
+    public void setBenutzerId(final Long benutzerId){this.benutzerId=benutzerId;}
 
 
     public Long getVeranstaltungId(){return veranstaltungId;}
@@ -195,11 +195,11 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
 
     public Long getSortierung(){return sortierung;}
 
-    public void setSortierung(final long sortierung){this.sortierung=sortierung;}
+    public void setSortierung(final Long sortierung){this.sortierung=sortierung;}
 
     public Long getSportjahr(){return sportjahr;}
 
-    public void setSportjahr(final long sportjahr){this.sportjahr=sportjahr;}
+    public void setSportjahr(final Long sportjahr){this.sportjahr=sportjahr;}
 
     public String getVeranstaltung_name() {
         return veranstaltung_name;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/api/types/DsbMannschaftDO.java
@@ -24,7 +24,6 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
     private String wettkampf_tag;
     private String wettkampf_ortsname;
     private String verein_name;
-    private Long mannschaft_nummer;
 
 
     /**
@@ -59,20 +58,28 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
         this.lastModifiedByUserId = lastModifiedByUserId;
         this.version = version;
     }
-    /**
-     * Constructor with mandatory parameters
-     * @param veranstaltung_name
-     * @param wettkampfTag
-     * @param wettkampf_ortsname
-     * @param verein_name
-     * @param mannschaft_nummer
-     */
-    public DsbMannschaftDO(final String veranstaltung_name, final String wettkampfTag, final String wettkampf_ortsname, final String verein_name, final long mannschaft_nummer) {
+
+     public DsbMannschaftDO(final Long id, final String name, final long vereinId, final long nummer, final long benutzerId,final Long veranstaltungId,
+                           final Long sortierung,
+                           final String veranstaltung_name, final String wettkampfTag, final String wettkampf_ortsname, final String verein_name) {
+         this.id = id;
+         this.name = name;
+         this.vereinId=vereinId;
+         this.nummer=nummer;
+         this.benutzerId=benutzerId;
+         this.veranstaltungId=veranstaltungId;
+         this.sortierung = sortierung;
         this.veranstaltung_name = veranstaltung_name;
         this.wettkampf_tag = wettkampfTag;
         this.wettkampf_ortsname = wettkampf_ortsname;
         this.verein_name = verein_name;
-        this.mannschaft_nummer = mannschaft_nummer;
+    }
+
+    public DsbMannschaftDO(final String veranstaltung_name, final String wettkampfTag, final String wettkampf_ortsname, final String verein_name) {
+        this.veranstaltung_name = veranstaltung_name;
+        this.wettkampf_tag = wettkampfTag;
+        this.wettkampf_ortsname = wettkampf_ortsname;
+        this.verein_name = verein_name;
     }
 
 
@@ -213,20 +220,13 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
     public void setVerein_name(final String verein_name) {
         this.verein_name = verein_name;
     }
-    public Long getMannschaft_nummer() {
-        return mannschaft_nummer;
-    }
-    public void setMannschaft_nummer(Long mannschaft_nummer) {
-        this.mannschaft_nummer = mannschaft_nummer;
-    }
 
 
     @Override
     public int hashCode() {
         return Objects.hash(id, vereinId,nummer,benutzerId,veranstaltungId,sortierung,
                 createdByUserId, lastModifiedAtUtc,
-                lastModifiedByUserId, version,id, veranstaltung_name, wettkampf_tag, wettkampf_ortsname, verein_name,
-                mannschaft_nummer);
+                lastModifiedByUserId, version,id, veranstaltung_name, wettkampf_tag, wettkampf_ortsname, verein_name);
     }
 
 
@@ -243,11 +243,10 @@ public class DsbMannschaftDO extends CommonDataObject implements DataObject {
                 vereinId == that.vereinId &&
                 benutzerId == that.benutzerId &&
                 sortierung == that.sortierung &&
-                mannschaft_nummer == that.mannschaft_nummer &&
+                nummer == that.nummer &&
                 createdByUserId == that.createdByUserId &&
                 lastModifiedByUserId == that.lastModifiedByUserId &&
                 version == that.version &&
-                Objects.equals(mannschaft_nummer,that.mannschaft_nummer) &&
                 Objects.equals(nummer, that.nummer) &&
                 Objects.equals(veranstaltungId, that.veranstaltungId) &&
                 Objects.equals(lastModifiedAtUtc, that.lastModifiedAtUtc) &&

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
@@ -78,8 +78,8 @@ public class DsbMannschaftComponentImpl implements DsbMannschaftComponent, DsbMa
     }
 
     @Override
-    public List<DsbMannschaftDO> findAllByWarteschlange() {
-        final List<DsbMannschaftBE> dsbMannschaftBeList = dsbMannschaftDAO.findAllByWarteschlange();
+    public List<DsbMannschaftDO> findAllByWarteschlange(Long veranstaltungsID) {
+        final List<DsbMannschaftBE> dsbMannschaftBeList = dsbMannschaftDAO.findAllByWarteschlange(veranstaltungsID);
         return this.fillAllNames(dsbMannschaftBeList.stream()
                 .map(DsbMannschaftMapper.toDsbMannschaftDO).toList());
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
@@ -78,8 +78,8 @@ public class DsbMannschaftComponentImpl implements DsbMannschaftComponent, DsbMa
     }
 
     @Override
-    public List<DsbMannschaftDO> findAllByWarteschlange(Long veranstaltungsID) {
-        final List<DsbMannschaftBE> dsbMannschaftBeList = dsbMannschaftDAO.findAllByWarteschlange(veranstaltungsID);
+    public List<DsbMannschaftDO> findAllByWarteschlange() {
+        final List<DsbMannschaftBE> dsbMannschaftBeList = dsbMannschaftDAO.findAllByWarteschlange();
         return this.fillAllNames(dsbMannschaftBeList.stream()
                 .map(DsbMannschaftMapper.toDsbMannschaftDO).toList());
     }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
@@ -71,10 +71,9 @@ public class DsbMannschaftDAO implements DataAccessObject {
 
      private static final String FIND_ALL_BY_WARTSCHLANGE =
             "SELECT m.* "
-                    + " FROM mannschaft m, veranstaltung v"
+                    + " FROM mannschaft m"
                     + " WHERE m.mannschaft_veranstaltung_id IS NULL"
-                    + " AND m.mannschaft_sportjahr = v.veranstaltung_sportjahr"
-                    + " AND v.veranstaltung_id = ?";
+                    + " AND m.mannschaft_sportjahr is NULL";
     private static final String FIND_ALL_BY_NAME =
             "SELECT a.* "
                     + "FROM mannschaft a, verein b "
@@ -158,8 +157,8 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * @return all dsbmannschaft entries in the waiting queue
      */
 
-    public List<DsbMannschaftBE> findAllByWarteschlange(final Long veranstaltungsID) {
-        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WARTSCHLANGE, veranstaltungsID);}
+    public List<DsbMannschaftBE> findAllByWarteschlange() {
+        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WARTSCHLANGE);}
 
     /**
      * Return all dsbmannschaft entries with the given name

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
@@ -29,10 +29,6 @@ public class DsbMannschaftDAO implements DataAccessObject {
     private static final String MANNSCHAFT_BE_EVENTID = "veranstaltungId";
     private static final String MANNSCHAFT_BE_USER_ID = "benutzerId";
     private static final String MANNSCHAFT_BE_SORTIERUNG = "sortierung";
-    private static final String MANNSCHAFT_BE_VEREINNAME = "vereinName";
-    private static final String MANNSCHAFT_BE_WETTKAMPFORT = "wettkampfOrtsname";
-    private static final String MANNSCHAFT_BE_WETTKAMPTAG = "wettkampfTag";
-    private static final String MANNSCHAFT_BE_VERANSTALTUNGSNAME = "veranstaltungName";
 
     private static final String MANNSCHAFT_TABLE_ID = "mannschaft_id";
     private static final String MANNSCHAFT_TABLE_TEAMID = "mannschaft_verein_id";
@@ -40,11 +36,6 @@ public class DsbMannschaftDAO implements DataAccessObject {
     private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
     private static final String MANNSCHAFT_TABLE_USER_ID = "mannschaft_benutzer_id";
     private static final String MANNSCHAFT_TABLE_SORTIERUNG = "mannschaft_sortierung";
-    private static final String MANNSCHAFT_TABLE_VEREINNAME = "verein_name";
-    private static final String MANNSCHAFT_TABLE_WETTKAMPFORT = "wettkampf_ortsname";
-    private static final String MANNSCHAFT_TABLE_WETTKAMPTAG = "wettkampf_tag";
-    private static final String MANNSCHAFT_TABLE_VERANSTALTUNGSNAME = "veranstaltung_name";
-
 
 
     // wrap all specific config parameters
@@ -76,14 +67,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
                     + " WHERE " + MANNSCHAFT_TABLE_EVENTID +" = ?"
                     + " ORDER BY "+MANNSCHAFT_TABLE_SORTIERUNG;
 
-    private static final String FIND_ALL_BY_WETTKAMPF_ID =
-            "select DISTINCT m.* FROM mannschaft m, wettkampf w, veranstaltung v\n" +
-                    "WHERE w.wettkampf_veranstaltung_id = v.veranstaltung_id\n" +
-                    "AND m.mannschaft_veranstaltung_id = v.veranstaltung_id\n" +
-                    "AND w.wettkampf_id = ?\n" +
-                    "group by m.mannschaft_id";
-
-    private static final String FIND_ALL_BY_WARTSCHLANGE =
+     private static final String FIND_ALL_BY_WARTSCHLANGE =
             "SELECT * "
                     + " FROM mannschaft"
                     + " WHERE mannschaft_veranstaltung_id IS NULL";
@@ -94,15 +78,6 @@ public class DsbMannschaftDAO implements DataAccessObject {
                     + "AND CONCAT(LOWER(b.verein_name), ' ' , "
                     + "LOWER(CAST(a.mannschaft_nummer AS TEXT))) LIKE LOWER(?) "
                     + "AND mannschaft_veranstaltung_id IS NULL";
-    private static final String FIND_VERSANSTALTUNGEN_BY_VEREIN =
-            "SELECT veranstaltung_name, wettkampf_tag, wettkampf_ortsname, verein_name, mannschaft_nummer "
-                    + "FROM veranstaltung ver "
-                    + "JOIN mannschaft m ON ver.veranstaltung_id = m.mannschaft_veranstaltung_id "
-                    + "JOIN verein v ON m.mannschaft_verein_id = v.verein_id "
-                    + "JOIN wettkampf ON ver.veranstaltung_id = wettkampf.wettkampf_veranstaltung_id "
-                    + "WHERE v.verein_id = ? "
-                    + "AND ver.veranstaltung_phase = 2 "
-                    + "GROUP BY mannschaft_nummer, veranstaltung_name, verein_name, wettkampf_ortsname, wettkampf_tag; ";
 
     private final BasicDAO basicDao;
 
@@ -128,10 +103,6 @@ public class DsbMannschaftDAO implements DataAccessObject {
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_SORTIERUNG, MANNSCHAFT_BE_SORTIERUNG);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_USER_ID, MANNSCHAFT_BE_USER_ID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_EVENTID, MANNSCHAFT_BE_EVENTID);
-        columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPFORT, MANNSCHAFT_BE_WETTKAMPFORT);
-        columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPTAG, MANNSCHAFT_BE_WETTKAMPTAG);
-        columnsToFieldsMap.put(MANNSCHAFT_TABLE_VEREINNAME, MANNSCHAFT_BE_VEREINNAME);
-        columnsToFieldsMap.put(MANNSCHAFT_TABLE_VERANSTALTUNGSNAME, MANNSCHAFT_BE_VERANSTALTUNGSNAME);
 
         // add technical columns
         columnsToFieldsMap.putAll(BasicDAO.getTechnicalColumnsToFieldsMap());
@@ -176,11 +147,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * @return all dbsmannschaft entries with the given Wettkampf-Id
      */
 
-    public List<DsbMannschaftBE> findAllByWettkampfId(final long id) {
-        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WETTKAMPF_ID, id);}
-    public List<DsbMannschaftBE> findVeranstaltungAndWettkampfById(final long id) {
-        return basicDao.selectEntityList(MANNSCHAFT, FIND_VERSANSTALTUNGEN_BY_VEREIN, id);}
-    /**
+        /**
      * Return all dsbmannschaft entries that are currently in the waiting queue
      *
      * @return all dsbmannschaft entries in the waiting queue
@@ -217,7 +184,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * Create a new dsbmitglied entry
      *
      * @param dsbMannschaftBE
-     * @param currentDsbMannschaftId
+     * @param currentUserId
      *
      * @return Business Entity corresponding to the created dsbmitglied entry
      */
@@ -232,12 +199,13 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * Update an existing dsbmitglied entry
      *
      * @param dsbMannschaftBE
-     * @param currentDsbMannschaftId
+     * @param currentUserId
      *
      * @return Business Entity corresponding to the updated dsbmitglied entry
      */
     public DsbMannschaftBE update(final DsbMannschaftBE dsbMannschaftBE, final long currentUserId) {
         basicDao.setModificationAttributes(dsbMannschaftBE, currentUserId);
+
 
         return basicDao.updateEntity(MANNSCHAFT, dsbMannschaftBE, MANNSCHAFT_BE_ID);
     }
@@ -247,7 +215,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * Delete existing mannschaft entry
      *
      * @param dsbMannschaftBE
-     * @param currentDsbMannschaftId
+     * @param currentUserId
      */
     public void delete(final DsbMannschaftBE dsbMannschaftBE, final long currentUserId) {
         basicDao.setModificationAttributes(dsbMannschaftBE, currentUserId);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAO.java
@@ -29,6 +29,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
     private static final String MANNSCHAFT_BE_EVENTID = "veranstaltungId";
     private static final String MANNSCHAFT_BE_USER_ID = "benutzerId";
     private static final String MANNSCHAFT_BE_SORTIERUNG = "sortierung";
+    private static final String MANNSCHAFT_BE_SPORTJAHR = "sportjahr";
 
     private static final String MANNSCHAFT_TABLE_ID = "mannschaft_id";
     private static final String MANNSCHAFT_TABLE_TEAMID = "mannschaft_verein_id";
@@ -36,6 +37,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
     private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
     private static final String MANNSCHAFT_TABLE_USER_ID = "mannschaft_benutzer_id";
     private static final String MANNSCHAFT_TABLE_SORTIERUNG = "mannschaft_sortierung";
+    private static final String MANNSCHAFT_TABLE_SPORTJAHR = "mannschaft_sportjahr";
 
 
     // wrap all specific config parameters
@@ -68,9 +70,11 @@ public class DsbMannschaftDAO implements DataAccessObject {
                     + " ORDER BY "+MANNSCHAFT_TABLE_SORTIERUNG;
 
      private static final String FIND_ALL_BY_WARTSCHLANGE =
-            "SELECT * "
-                    + " FROM mannschaft"
-                    + " WHERE mannschaft_veranstaltung_id IS NULL";
+            "SELECT m.* "
+                    + " FROM mannschaft m, veranstaltung v"
+                    + " WHERE m.mannschaft_veranstaltung_id IS NULL"
+                    + " AND m.mannschaft_sportjahr = v.veranstaltung_sportjahr"
+                    + " AND v.veranstaltung_id = ?";
     private static final String FIND_ALL_BY_NAME =
             "SELECT a.* "
                     + "FROM mannschaft a, verein b "
@@ -101,6 +105,7 @@ public class DsbMannschaftDAO implements DataAccessObject {
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_TEAMID, MANNSCHAFT_BE_TEAMID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_NUMBER, MANNSCHAFT_BE_NUMBER);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_SORTIERUNG, MANNSCHAFT_BE_SORTIERUNG);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_SPORTJAHR, MANNSCHAFT_BE_SPORTJAHR);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_USER_ID, MANNSCHAFT_BE_USER_ID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_EVENTID, MANNSCHAFT_BE_EVENTID);
 
@@ -153,8 +158,8 @@ public class DsbMannschaftDAO implements DataAccessObject {
      * @return all dsbmannschaft entries in the waiting queue
      */
 
-    public List<DsbMannschaftBE> findAllByWarteschlange() {
-        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WARTSCHLANGE);}
+    public List<DsbMannschaftBE> findAllByWarteschlange(final Long veranstaltungsID) {
+        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WARTSCHLANGE, veranstaltungsID);}
 
     /**
      * Return all dsbmannschaft entries with the given name

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
@@ -25,7 +25,7 @@ public class DsbMannschaftDAOext implements DataAccessObject {
 
 
     private static final String MANNSCHAFT_BE_ID = "id";
-    private static final String MANNSCHAFT_BE_TEAMID = "vereinId";
+    private static final String MANNSCHAFT_BE_VEREINID = "vereinId";
     private static final String MANNSCHAFT_BE_NUMBER = "nummer";
     private static final String MANNSCHAFT_BE_EVENTID = "veranstaltungId";
     private static final String MANNSCHAFT_BE_USER_ID = "benutzerId";
@@ -36,10 +36,10 @@ public class DsbMannschaftDAOext implements DataAccessObject {
     private static final String MANNSCHAFT_BE_VERANSTALTUNGSNAME = "veranstaltungName";
 
     private static final String MANNSCHAFT_TABLE_ID = "mannschaft_id";
-    private static final String MANNSCHAFT_TABLE_TEAMID = "mannschaft_verein_id";
+    private static final String MANNSCHAFT_TABLE_VEREINID = "mannschaft_verein_id";
     private static final String MANNSCHAFT_TABLE_NUMBER = "mannschaft_nummer";
-    private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
     private static final String MANNSCHAFT_TABLE_USER_ID = "mannschaft_benutzer_id";
+    private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
     private static final String MANNSCHAFT_TABLE_SORTIERUNG = "mannschaft_sortierung";
     private static final String MANNSCHAFT_TABLE_VEREINNAME = "verein_name";
     private static final String MANNSCHAFT_TABLE_WETTKAMPFORT = "wettkampf_ortsname";
@@ -92,12 +92,12 @@ public class DsbMannschaftDAOext implements DataAccessObject {
         final Map<String, String> columnsToFieldsMap = new HashMap<>();
 
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_ID, MANNSCHAFT_BE_ID);
-        columnsToFieldsMap.put(MANNSCHAFT_TABLE_TEAMID, MANNSCHAFT_BE_TEAMID);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_VEREINID, MANNSCHAFT_BE_VEREINID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_NUMBER, MANNSCHAFT_BE_NUMBER);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_SORTIERUNG, MANNSCHAFT_BE_SORTIERUNG);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_USER_ID, MANNSCHAFT_BE_USER_ID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_EVENTID, MANNSCHAFT_BE_EVENTID);
-       columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPFORT, MANNSCHAFT_BE_WETTKAMPFORT);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPFORT, MANNSCHAFT_BE_WETTKAMPFORT);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPTAG, MANNSCHAFT_BE_WETTKAMPTAG);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_VEREINNAME, MANNSCHAFT_BE_VEREINNAME);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_VERANSTALTUNGSNAME, MANNSCHAFT_BE_VERANSTALTUNGSNAME);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
@@ -30,6 +30,7 @@ public class DsbMannschaftDAOext implements DataAccessObject {
     private static final String MANNSCHAFT_BE_EVENTID = "veranstaltungId";
     private static final String MANNSCHAFT_BE_USER_ID = "benutzerId";
     private static final String MANNSCHAFT_BE_SORTIERUNG = "sortierung";
+    private static final String MANNSCHAFT_BE_SPORTJAHR = "sportjahr";
     private static final String MANNSCHAFT_BE_VEREINNAME = "vereinName";
     private static final String MANNSCHAFT_BE_WETTKAMPFORT = "wettkampfOrtsname";
     private static final String MANNSCHAFT_BE_WETTKAMPTAG = "wettkampfTag";
@@ -41,6 +42,7 @@ public class DsbMannschaftDAOext implements DataAccessObject {
     private static final String MANNSCHAFT_TABLE_USER_ID = "mannschaft_benutzer_id";
     private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
     private static final String MANNSCHAFT_TABLE_SORTIERUNG = "mannschaft_sortierung";
+    private static final String MANNSCHAFT_TABLE_SPORTJAHR = "mannschaft_sportjahr";
     private static final String MANNSCHAFT_TABLE_VEREINNAME = "verein_name";
     private static final String MANNSCHAFT_TABLE_WETTKAMPFORT = "wettkampf_ortsname";
     private static final String MANNSCHAFT_TABLE_WETTKAMPTAG = "wettkampf_tag";
@@ -95,6 +97,7 @@ public class DsbMannschaftDAOext implements DataAccessObject {
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_VEREINID, MANNSCHAFT_BE_VEREINID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_NUMBER, MANNSCHAFT_BE_NUMBER);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_SORTIERUNG, MANNSCHAFT_BE_SORTIERUNG);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_SPORTJAHR, MANNSCHAFT_BE_SPORTJAHR);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_USER_ID, MANNSCHAFT_BE_USER_ID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_EVENTID, MANNSCHAFT_BE_EVENTID);
         columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPFORT, MANNSCHAFT_BE_WETTKAMPFORT);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
@@ -1,0 +1,123 @@
+package de.bogenliga.application.business.dsbmannschaft.impl.dao;
+
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
+import de.bogenliga.application.common.component.dao.BasicDAO;
+import de.bogenliga.application.common.component.dao.BusinessEntityConfiguration;
+import de.bogenliga.application.common.component.dao.DataAccessObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class DsbMannschaftDAOext implements DataAccessObject {
+
+    // define the logger context
+    private static final Logger LOGGER = LoggerFactory.getLogger(DsbMannschaftDAOext.class);
+
+    // table name in the database
+    private static final String TABLE = "mannschaft";
+    // business entity parameter names
+
+
+    private static final String MANNSCHAFT_BE_ID = "id";
+    private static final String MANNSCHAFT_BE_TEAMID = "vereinId";
+    private static final String MANNSCHAFT_BE_NUMBER = "nummer";
+    private static final String MANNSCHAFT_BE_EVENTID = "veranstaltungId";
+    private static final String MANNSCHAFT_BE_USER_ID = "benutzerId";
+    private static final String MANNSCHAFT_BE_SORTIERUNG = "sortierung";
+    private static final String MANNSCHAFT_BE_VEREINNAME = "vereinName";
+    private static final String MANNSCHAFT_BE_WETTKAMPFORT = "wettkampfOrtsname";
+    private static final String MANNSCHAFT_BE_WETTKAMPTAG = "wettkampfTag";
+    private static final String MANNSCHAFT_BE_VERANSTALTUNGSNAME = "veranstaltungName";
+
+    private static final String MANNSCHAFT_TABLE_ID = "mannschaft_id";
+    private static final String MANNSCHAFT_TABLE_TEAMID = "mannschaft_verein_id";
+    private static final String MANNSCHAFT_TABLE_NUMBER = "mannschaft_nummer";
+    private static final String MANNSCHAFT_TABLE_EVENTID = "mannschaft_veranstaltung_id";
+    private static final String MANNSCHAFT_TABLE_USER_ID = "mannschaft_benutzer_id";
+    private static final String MANNSCHAFT_TABLE_SORTIERUNG = "mannschaft_sortierung";
+    private static final String MANNSCHAFT_TABLE_VEREINNAME = "verein_name";
+    private static final String MANNSCHAFT_TABLE_WETTKAMPFORT = "wettkampf_ortsname";
+    private static final String MANNSCHAFT_TABLE_WETTKAMPTAG = "wettkampf_tag";
+    private static final String MANNSCHAFT_TABLE_VERANSTALTUNGSNAME = "veranstaltung_name";
+
+
+
+    // wrap all specific config parameters
+    private static final BusinessEntityConfiguration<DsbMannschaftBEext> MANNSCHAFT = new BusinessEntityConfiguration<>(
+            DsbMannschaftBEext.class, TABLE, getColumnsToFieldsMap(), LOGGER);
+
+    /*
+     * SQL queries
+     */
+
+    private static final String FIND_ALL_BY_WETTKAMPF_ID =
+            "select DISTINCT m.* FROM mannschaft m, wettkampf w, veranstaltung v\n" +
+                    "WHERE w.wettkampf_veranstaltung_id = v.veranstaltung_id\n" +
+                    "AND m.mannschaft_veranstaltung_id = v.veranstaltung_id\n" +
+                    "AND w.wettkampf_id = ?\n" +
+                    "group by m.mannschaft_id";
+
+    private static final String FIND_VERSANSTALTUNGEN_BY_VEREIN =
+            "SELECT veranstaltung_name, wettkampf_tag, wettkampf_ortsname, verein_name, mannschaft_nummer "
+                    + "FROM veranstaltung ver "
+                    + "JOIN mannschaft m ON ver.veranstaltung_id = m.mannschaft_veranstaltung_id "
+                    + "JOIN verein v ON m.mannschaft_verein_id = v.verein_id "
+                    + "JOIN wettkampf ON ver.veranstaltung_id = wettkampf.wettkampf_veranstaltung_id "
+                    + "WHERE v.verein_id = ? "
+                    + "AND ver.veranstaltung_phase = 2 "
+                    + "GROUP BY mannschaft_nummer, veranstaltung_name, verein_name, wettkampf_ortsname, wettkampf_tag; ";
+
+    private final BasicDAO basicDao;
+
+
+    /**
+     * Initialize the transaction manager to provide a database connection
+     *
+     * @param basicDao to handle the commonly used database operations
+     */
+    @Autowired
+    public DsbMannschaftDAOext(final BasicDAO basicDao) {
+        this.basicDao = basicDao;
+    }
+
+
+    // table column label mapping to the business entity parameter names
+    private static Map<String, String> getColumnsToFieldsMap() {
+        final Map<String, String> columnsToFieldsMap = new HashMap<>();
+
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_ID, MANNSCHAFT_BE_ID);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_TEAMID, MANNSCHAFT_BE_TEAMID);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_NUMBER, MANNSCHAFT_BE_NUMBER);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_SORTIERUNG, MANNSCHAFT_BE_SORTIERUNG);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_USER_ID, MANNSCHAFT_BE_USER_ID);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_EVENTID, MANNSCHAFT_BE_EVENTID);
+       columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPFORT, MANNSCHAFT_BE_WETTKAMPFORT);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_WETTKAMPTAG, MANNSCHAFT_BE_WETTKAMPTAG);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_VEREINNAME, MANNSCHAFT_BE_VEREINNAME);
+        columnsToFieldsMap.put(MANNSCHAFT_TABLE_VERANSTALTUNGSNAME, MANNSCHAFT_BE_VERANSTALTUNGSNAME);
+
+        // add technical columns
+        columnsToFieldsMap.putAll(BasicDAO.getTechnicalColumnsToFieldsMap());
+
+        return columnsToFieldsMap;
+    }
+
+
+
+    public List<DsbMannschaftBEext> findAllByWettkampfId(final long id) {
+        return basicDao.selectEntityList(MANNSCHAFT, FIND_ALL_BY_WETTKAMPF_ID, id);}
+    public List<DsbMannschaftBEext> findVeranstaltungAndWettkampfById(final long id) {
+        return basicDao.selectEntityList(MANNSCHAFT, FIND_VERSANSTALTUNGEN_BY_VEREIN, id);}
+    /**
+     * Return all dsbmannschaft entries that are currently in the waiting queue
+     *
+     * @return all dsbmannschaft entries in the waiting queue
+     */
+
+}

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
@@ -12,6 +12,7 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
     private Long veranstaltungId;
     private Long benutzerId;
     private Long sortierung;
+    private Long sportjahr;
 
     public DsbMannschaftBE() {/*empty constructor*/}
 
@@ -75,6 +76,15 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
         this.sortierung = sortierung;
     }
 
+    public Long getSportjahr() {
+        return sportjahr;
+    }
+
+
+    public void setSportjahr(final Long sportjahr) {
+        this.sportjahr = sportjahr;
+    }
+
 
 
 
@@ -87,6 +97,7 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
                 ", mannschaftVeranstaltungId='" + veranstaltungId + '\'' +
                 ", mannschaftBenutzerId='" + benutzerId + '\'' +
                 ", mannschaftSortierung='" + sortierung + '\'' +
+                ", mannschaftSortierung='" + sportjahr + '\'' +
                 '}';
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
@@ -12,29 +12,9 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
     private Long veranstaltungId;
     private Long benutzerId;
     private Long sortierung;
-    private String veranstaltungName;
-    private String wettkampfTag;
-    private String wettkampfOrtsname;
-    private String vereinName;
-    private Long mannschaftNummer;
-
 
     public DsbMannschaftBE() {/*empty constructor*/}
-    /**
-     * Constructor with mandatory parameters
-     * @param veranstaltungName
-     * @param wettkampfTag
-     * @param wettkampfOrtsname
-     * @param vereinName
-     * @param nummer
-     */
-    public DsbMannschaftBE(final String veranstaltungName,final String wettkampfTag, final String wettkampfOrtsname, final String vereinName, final long nummer) {
-        this.veranstaltungName = veranstaltungName;
-        this.wettkampfTag = wettkampfTag;
-        this.wettkampfOrtsname = wettkampfOrtsname;
-        this.vereinName = vereinName;
-        this.mannschaftNummer = nummer;
-    }
+
 
     public Long getId() {
         return id;
@@ -95,44 +75,7 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
         this.sortierung = sortierung;
     }
 
-    public String getVeranstaltungName() {
-        return veranstaltungName;
-    }
 
-    public void setVeranstaltungName(final String veranstaltungName) {
-        this.veranstaltungName = veranstaltungName;
-    }
-
-    public String getWettkampfTag() {
-        return wettkampfTag;
-    }
-
-    public void setWettkampfTag(final String wettkampfTag) {
-        this.wettkampfTag = wettkampfTag;
-    }
-
-    public String getWettkampfOrtsname() {
-        return wettkampfOrtsname;
-    }
-
-    public void setWettkampfOrtsname(final String wettkampfOrtsname) {
-        this.wettkampfOrtsname = wettkampfOrtsname;
-    }
-
-    public String getVereinName() {
-        return vereinName;
-    }
-
-    public void setVereinName(final String vereinName) {
-        this.vereinName = vereinName;
-    }
-
-    public Long getMannschaftNummer() {
-        return mannschaftNummer;
-    }
-    public void setMannschaftNummer(Long mannschaftNummer) {
-        this.mannschaftNummer = mannschaftNummer;
-    }
 
 
     @Override

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
@@ -16,6 +16,15 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
 
     public DsbMannschaftBE() {/*empty constructor*/}
 
+    public DsbMannschaftBE(Long id, Long vereinId, Long nummer, Long veranstaltungId, Long benutzerId, Long sortierung, Long sportjahr) {
+        this.id = id;
+        this.vereinId = vereinId;
+        this.nummer = nummer;
+        this.veranstaltungId = veranstaltungId;
+        this.benutzerId = benutzerId;
+        this.sortierung = sortierung;
+        this.sportjahr = sportjahr;
+    }
 
     public Long getId() {
         return id;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBE.java
@@ -97,7 +97,7 @@ public class DsbMannschaftBE extends CommonBusinessEntity implements BusinessEnt
                 ", mannschaftVeranstaltungId='" + veranstaltungId + '\'' +
                 ", mannschaftBenutzerId='" + benutzerId + '\'' +
                 ", mannschaftSortierung='" + sortierung + '\'' +
-                ", mannschaftSortierung='" + sportjahr + '\'' +
+                ", mannschaftSportjahr='" + sportjahr + '\'' +
                 '}';
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
@@ -1,0 +1,144 @@
+package de.bogenliga.application.business.dsbmannschaft.impl.entity;
+
+import de.bogenliga.application.common.component.entity.BusinessEntity;
+import de.bogenliga.application.common.component.entity.CommonBusinessEntity;
+
+public class DsbMannschaftBEext extends CommonBusinessEntity implements BusinessEntity {
+
+    private static final long serialVersionUID = -6431886856322437597L;
+    private Long id;
+    private Long vereinId;
+    private Long nummer;
+    private Long veranstaltungId;
+    private Long benutzerId;
+    private Long sortierung;
+    private String veranstaltungName;
+    private String wettkampfTag;
+    private String wettkampfOrtsname;
+    private String vereinName;
+
+
+    public DsbMannschaftBEext() {/*empty constructor*/}
+    /**
+     * Constructor with mandatory parameters
+     * @param veranstaltungName
+     * @param wettkampfTag
+     * @param wettkampfOrtsname
+     * @param vereinName
+     */
+    public DsbMannschaftBEext(final String veranstaltungName, final String wettkampfTag, final String wettkampfOrtsname, final String vereinName) {
+        this.veranstaltungName = veranstaltungName;
+        this.wettkampfTag = wettkampfTag;
+        this.wettkampfOrtsname = wettkampfOrtsname;
+        this.vereinName = vereinName;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+
+    public void setId(final Long id) {
+        this.id = id;
+    }
+
+
+    public Long getVereinId() {
+        return vereinId;
+    }
+
+
+    public void setVereinId(final Long vereinId) {
+        this.vereinId = vereinId;
+    }
+
+
+    public Long getNummer() {
+        return nummer;
+    }
+
+
+    public void setNummer(final Long nummer) {
+        this.nummer = nummer;
+    }
+
+
+    public Long getVeranstaltungId() {
+        return veranstaltungId;
+    }
+
+
+    public void setVeranstaltungId(final Long veranstaltungId) {
+        this.veranstaltungId = veranstaltungId;
+    }
+
+
+    public Long getBenutzerId() {
+        return benutzerId;
+    }
+
+
+    public void setBenutzerId(final Long benutzerId) {
+        this.benutzerId = benutzerId;
+    }
+
+
+    public Long getSortierung() {
+        return sortierung;
+    }
+
+
+    public void setSortierung(final Long sortierung) {
+        this.sortierung = sortierung;
+    }
+
+    public String getVeranstaltungName() {
+        return veranstaltungName;
+    }
+
+    public void setVeranstaltungName(final String veranstaltungName) {
+        this.veranstaltungName = veranstaltungName;
+    }
+
+    public String getWettkampfTag() {
+        return wettkampfTag;
+    }
+
+    public void setWettkampfTag(final String wettkampfTag) {
+        this.wettkampfTag = wettkampfTag;
+    }
+
+    public String getWettkampfOrtsname() {
+        return wettkampfOrtsname;
+    }
+
+    public void setWettkampfOrtsname(final String wettkampfOrtsname) {
+        this.wettkampfOrtsname = wettkampfOrtsname;
+    }
+
+    public String getVereinName() {
+        return vereinName;
+    }
+
+    public void setVereinName(final String vereinName) {
+        this.vereinName = vereinName;
+    }
+
+
+
+    @Override
+    public String toString() {
+        return "DsbMannschaftBEext{" +
+                "mannschaftId=" + id +
+                ", mannschaftVereinId='" + vereinId + '\'' +
+                ", mannschaftNummer='" + nummer + '\'' +
+                ", mannschaftVeranstaltungId='" + veranstaltungId + '\'' +
+                ", mannschaftBenutzerId='" + benutzerId + '\'' +
+                ", mannschaftSortierung='" + sortierung + '\'' +
+                ", VeranstaltungName='" + veranstaltungName + '\'' +
+                ", WettkampfTag='" + wettkampfTag + '\'' +
+                ", WettkampfOrtsname='" + wettkampfOrtsname + '\'' +
+                ", VereinName='" + vereinName + '\'' +
+                '}';
+    }
+}

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
@@ -20,7 +20,10 @@ public class DsbMannschaftBEext extends DsbMannschaftBE implements BusinessEntit
      * @param wettkampfOrtsname
      * @param vereinName
      */
-    public DsbMannschaftBEext(final String veranstaltungName, final String wettkampfTag, final String wettkampfOrtsname, final String vereinName) {
+    public DsbMannschaftBEext(final Long id, final Long vereinId, final Long nummer, final Long veranstaltungId,
+                              final Long benutzerId, final Long sortierung, final Long sportjahr, final String veranstaltungName,
+                              final String wettkampfTag, final String wettkampfOrtsname, final String vereinName) {
+        super(id, vereinId, nummer, veranstaltungId, benutzerId, sortierung, sportjahr);
         this.veranstaltungName = veranstaltungName;
         this.wettkampfTag = wettkampfTag;
         this.wettkampfOrtsname = wettkampfOrtsname;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/entity/DsbMannschaftBEext.java
@@ -3,22 +3,16 @@ package de.bogenliga.application.business.dsbmannschaft.impl.entity;
 import de.bogenliga.application.common.component.entity.BusinessEntity;
 import de.bogenliga.application.common.component.entity.CommonBusinessEntity;
 
-public class DsbMannschaftBEext extends CommonBusinessEntity implements BusinessEntity {
+public class DsbMannschaftBEext extends DsbMannschaftBE implements BusinessEntity {
 
     private static final long serialVersionUID = -6431886856322437597L;
-    private Long id;
-    private Long vereinId;
-    private Long nummer;
-    private Long veranstaltungId;
-    private Long benutzerId;
-    private Long sortierung;
-    private String veranstaltungName;
+   private String veranstaltungName;
     private String wettkampfTag;
     private String wettkampfOrtsname;
     private String vereinName;
 
 
-    public DsbMannschaftBEext() {/*empty constructor*/}
+    public DsbMannschaftBEext()  {/*empty constructor*/}
     /**
      * Constructor with mandatory parameters
      * @param veranstaltungName
@@ -33,64 +27,6 @@ public class DsbMannschaftBEext extends CommonBusinessEntity implements Business
         this.vereinName = vereinName;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-
-    public void setId(final Long id) {
-        this.id = id;
-    }
-
-
-    public Long getVereinId() {
-        return vereinId;
-    }
-
-
-    public void setVereinId(final Long vereinId) {
-        this.vereinId = vereinId;
-    }
-
-
-    public Long getNummer() {
-        return nummer;
-    }
-
-
-    public void setNummer(final Long nummer) {
-        this.nummer = nummer;
-    }
-
-
-    public Long getVeranstaltungId() {
-        return veranstaltungId;
-    }
-
-
-    public void setVeranstaltungId(final Long veranstaltungId) {
-        this.veranstaltungId = veranstaltungId;
-    }
-
-
-    public Long getBenutzerId() {
-        return benutzerId;
-    }
-
-
-    public void setBenutzerId(final Long benutzerId) {
-        this.benutzerId = benutzerId;
-    }
-
-
-    public Long getSortierung() {
-        return sortierung;
-    }
-
-
-    public void setSortierung(final Long sortierung) {
-        this.sortierung = sortierung;
-    }
 
     public String getVeranstaltungName() {
         return veranstaltungName;
@@ -129,12 +65,6 @@ public class DsbMannschaftBEext extends CommonBusinessEntity implements Business
     @Override
     public String toString() {
         return "DsbMannschaftBEext{" +
-                "mannschaftId=" + id +
-                ", mannschaftVereinId='" + vereinId + '\'' +
-                ", mannschaftNummer='" + nummer + '\'' +
-                ", mannschaftVeranstaltungId='" + veranstaltungId + '\'' +
-                ", mannschaftBenutzerId='" + benutzerId + '\'' +
-                ", mannschaftSortierung='" + sortierung + '\'' +
                 ", VeranstaltungName='" + veranstaltungName + '\'' +
                 ", WettkampfTag='" + wettkampfTag + '\'' +
                 ", WettkampfOrtsname='" + wettkampfOrtsname + '\'' +

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
@@ -30,6 +30,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         final Long benutzerId = be.getBenutzerId();
         final Long veranstaltungId = be.getVeranstaltungId();
         final Long sortierung = be.getSortierung();
+        final Long sportjahr = be.getSportjahr();
         final String name = null; //empty
 
 
@@ -41,7 +42,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         OffsetDateTime createdAtUtc = DateProvider.convertTimestamp(be.getCreatedAtUtc());
         OffsetDateTime lastModifiedAtUtc = DateProvider.convertTimestamp(be.getLastModifiedAtUtc());
 
-        return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung,
+        return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung, sportjahr,
                 createdAtUtc, createdByUserId, lastModifiedAtUtc, lastModifiedByUserId, version);
     };
     public static final Function<DsbMannschaftBEext, DsbMannschaftDO> toDsbMannschaftVerUWettDO = be -> {
@@ -52,6 +53,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         final Long benutzerId = be.getBenutzerId();
         final Long veranstaltungId = be.getVeranstaltungId();
         final Long sortierung = be.getSortierung();
+        final Long sportjahr = be.getSportjahr();
         final String name = be.getVereinName()+be.getNummer().toString();
 
         final String veranstaltungName = be.getVeranstaltungName();
@@ -59,7 +61,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         final String wettkampfOrtsname = be.getWettkampfOrtsname();
         final String vereinName = be.getVereinName();
 
-        return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung, veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName);
+        return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung, sportjahr, veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName);
     };
 
 
@@ -80,6 +82,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         dsbMannschaftBE.setBenutzerId(dsbMannschaftDO.getBenutzerId());
         dsbMannschaftBE.setVeranstaltungId(dsbMannschaftDO.getVeranstaltungId());
         dsbMannschaftBE.setSortierung(dsbMannschaftDO.getSortierung());
+        dsbMannschaftBE.setSportjahr(dsbMannschaftDO.getSportjahr());
 
 
         dsbMannschaftBE.setCreatedAtUtc(createdAtUtcTimestamp);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
@@ -46,13 +46,20 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
     };
     public static final Function<DsbMannschaftBEext, DsbMannschaftDO> toDsbMannschaftVerUWettDO = be -> {
 
+        final Long id = be.getId();
+        final Long vereinId = be.getVereinId();
+        final Long nummer = be.getNummer();
+        final Long benutzerId = be.getBenutzerId();
+        final Long veranstaltungId = be.getVeranstaltungId();
+        final Long sortierung = be.getSortierung();
+        final String name = be.getVereinName()+be.getNummer().toString();
+
         final String veranstaltungName = be.getVeranstaltungName();
         final String wettkampfTag = be.getWettkampfTag();
         final String wettkampfOrtsname = be.getWettkampfOrtsname();
         final String vereinName = be.getVereinName();
-        final Long mannschaftNummer = be.getNummer();
 
-        return new DsbMannschaftDO(veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName,mannschaftNummer);
+        return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung, veranstaltungName, wettkampfTag, wettkampfOrtsname, vereinName);
     };
 
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapper.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBE;
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
 import de.bogenliga.application.common.component.mapping.ValueObjectMapper;
 import de.bogenliga.application.common.time.DateProvider;
 
@@ -43,7 +44,7 @@ public class DsbMannschaftMapper implements ValueObjectMapper {
         return new DsbMannschaftDO(id, name, vereinId, nummer, benutzerId, veranstaltungId, sortierung,
                 createdAtUtc, createdByUserId, lastModifiedAtUtc, lastModifiedByUserId, version);
     };
-    public static final Function<DsbMannschaftBE, DsbMannschaftDO> toDsbMannschaftVerUWettDO = be -> {
+    public static final Function<DsbMannschaftBEext, DsbMannschaftDO> toDsbMannschaftVerUWettDO = be -> {
 
         final String veranstaltungName = be.getVeranstaltungName();
         final String wettkampfTag = be.getWettkampfTag();

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/entity/AltsystemMannschaftTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/entity/AltsystemMannschaftTest.java
@@ -61,7 +61,7 @@ public class AltsystemMannschaftTest {
 
         DsbMannschaftDO result = new DsbMannschaftDO();
         result.setId(1L);
-        result.setNummer(3);
+        result.setNummer(3L);
         result.setVeranstaltungId(1L);
         result.setVereinId(1L);
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/altsystem/mannschafft/mapper/AltsystemVeranstaltungMapperTest.java
@@ -427,7 +427,7 @@ public class AltsystemVeranstaltungMapperTest {
 
     public static List<DsbMannschaftDO> get4MockedDsbMannschaften(){
         List<DsbMannschaftDO> dsbMannschaften = new LinkedList<>();
-        for (int i = 1; i <= 4; i++) {
+        for (Long i = 1L; i <= 4L; i++) {
             DsbMannschaftDO dsbMannschaftDO = new DsbMannschaftDO((long)i, i);
             dsbMannschaften.add(dsbMannschaftDO);
         }
@@ -436,7 +436,7 @@ public class AltsystemVeranstaltungMapperTest {
 
     public static List<DsbMannschaftDO> get6MockedDsbMannschaften(){
         List<DsbMannschaftDO> dsbMannschaften = new LinkedList<>();
-        for (int i = 1; i <= 6; i++) {
+        for (Long i = 1L; i <= 6L; i++) {
             DsbMannschaftDO dsbMannschaftDO = new DsbMannschaftDO((long)i, i);
             dsbMannschaften.add(dsbMannschaftDO);
         }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -54,7 +54,8 @@ public class DsbMannschaftComponentImplTest {
     private static final String WETTKAMPTAG ="1";
     private static final long MANNSCHAFTNUMMER = 0;
     private static final long DB_SORTIERUNG =0L;
-    
+    private static final long SPORTJAHR =2024L;
+
     private static final String VEREIN_NAME = "Testverein";
     private static final String MA_NAME = VEREIN_NAME+" "+ NUMMER;
     private static final long PLATZHALTER_ID = 99L;
@@ -86,7 +87,8 @@ public class DsbMannschaftComponentImplTest {
         expectedBE.setNummer(NUMMER);
         expectedBE.setBenutzerId(BENUTZER_ID);
         expectedBE.setVeranstaltungId(VERANSTALTUNG_ID);
-        expectedBE.setSortierung(SORTIERUNG);
+         expectedBE.setSortierung(SORTIERUNG);
+         expectedBE.setSportjahr(SPORTJAHR);
 
 
 
@@ -100,6 +102,7 @@ public class DsbMannschaftComponentImplTest {
         dsbMannschaftBE.setBenutzerId(BENUTZER_ID);
         dsbMannschaftBE.setVeranstaltungId(VERANSTALTUNG_ID);
         dsbMannschaftBE.setSortierung(SORTIERUNG);
+        dsbMannschaftBE.setSportjahr(SPORTJAHR);
 
         return dsbMannschaftBE ;
     }
@@ -111,7 +114,8 @@ public class DsbMannschaftComponentImplTest {
                 NUMMER,
                 BENUTZER_ID,
                 VERANSTALTUNG_ID,
-                SORTIERUNG);
+                SORTIERUNG,
+                SPORTJAHR);
     }
     public static DsbMannschaftDO getDsbMannschaftDOVERANDWETT() {
         return new DsbMannschaftDO(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
@@ -126,7 +130,8 @@ public class DsbMannschaftComponentImplTest {
                 NUMMER,
                 BENUTZER_ID,
                 VERANSTALTUNG_ID,
-                SORTIERUNG);
+                SORTIERUNG,
+                SPORTJAHR);
     }
 
     public static DsbMannschaftDO getSortierungsDO(){
@@ -137,7 +142,8 @@ public class DsbMannschaftComponentImplTest {
                 0L,
                 0L,
                 0L,
-                SORTIERUNG
+                SORTIERUNG,
+                0L
         );
     }
 
@@ -384,10 +390,10 @@ public class DsbMannschaftComponentImplTest {
         expectedBE.setVeranstaltungId(null);
 
         // configure mocks
-        when(dsbMannschaftDAO.findAllByWarteschlange()).thenReturn(expectedBEList);
+        when(dsbMannschaftDAO.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID)).thenReturn(expectedBEList);
 
         // call test method
-        final List<DsbMannschaftDO> actual = underTest.findAllByWarteschlange();
+        final List<DsbMannschaftDO> actual = underTest.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID);
 
         // assert result
         assertThat(actual)
@@ -412,7 +418,7 @@ public class DsbMannschaftComponentImplTest {
 
 
         // verify invocations
-        verify(dsbMannschaftDAO).findAllByWarteschlange();
+        verify(dsbMannschaftDAO).findAllByWarteschlange(anyLong());
         verify(vereinComponent).findById(anyLong());
     }
     @Test
@@ -556,6 +562,7 @@ public class DsbMannschaftComponentImplTest {
                 NUMMER,
                 VERANSTALTUNG_ID,
                 SORTIERUNG,
+                SPORTJAHR,
                 dateTime,
                 USER,
                 VERSION);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -1,6 +1,8 @@
 package de.bogenliga.application.business.dsbmannschaft.impl.business;
 
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
+import de.bogenliga.application.business.dsbmannschaft.impl.dao.DsbMannschaftDAOext;
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
 import de.bogenliga.application.business.dsbmannschaft.impl.dao.DsbMannschaftDAO;
 import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBE;
 import de.bogenliga.application.business.mannschaftsmitglied.api.types.MannschaftsmitgliedDO;
@@ -60,6 +62,8 @@ public class DsbMannschaftComponentImplTest {
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
     @Mock
+    private DsbMannschaftDAOext dsbMannschaftDAOext ;
+    @Mock
     private DsbMannschaftDAO dsbMannschaftDAO ;
     @Mock
     private VereinComponent vereinComponent;
@@ -74,11 +78,7 @@ public class DsbMannschaftComponentImplTest {
 
 
 
-    /***
-     * Utility methods for creating business entities/data objects.
-     * Also used by other test classes.
-     */
-    public static DsbMannschaftBE getDsbMannschaftBE() {
+     public static DsbMannschaftBE getDsbMannschaftBE() {
         final DsbMannschaftBE expectedBE = new DsbMannschaftBE();
 
         expectedBE.setId(ID);
@@ -92,8 +92,8 @@ public class DsbMannschaftComponentImplTest {
 
         return expectedBE;
     }
-    public static DsbMannschaftBE getDsbMannschaftBEVERANDWETT() {
-        DsbMannschaftBE dsbMannschaftBE = new DsbMannschaftBE(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME, MANNSCHAFTNUMMER);
+    public static DsbMannschaftBEext getDsbMannschaftBEext() {
+        DsbMannschaftBEext dsbMannschaftBE = new DsbMannschaftBEext(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
         dsbMannschaftBE.setNummer(MANNSCHAFTNUMMER);
         return dsbMannschaftBE ;
     }
@@ -108,7 +108,7 @@ public class DsbMannschaftComponentImplTest {
                 SORTIERUNG);
     }
     public static DsbMannschaftDO getDsbMannschaftDOVERANDWETT() {
-        return new DsbMannschaftDO(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME, MANNSCHAFTNUMMER);
+        return new DsbMannschaftDO(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
     }
 
 
@@ -284,12 +284,12 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void findAllByWettkampfId() {
         // prepare test data
-        final DsbMannschaftBE expectedBE = getDsbMannschaftBE();
-        final List<DsbMannschaftBE> expectedBEList = Collections.singletonList(expectedBE);
+        final DsbMannschaftBEext expectedBE = getDsbMannschaftBEext();
+        final List<DsbMannschaftBEext> expectedBEList = Collections.singletonList(expectedBE);
 
         // configure mocks
-        when(dsbMannschaftDAO.findAllByWettkampfId(WETTKAMPF_ID)).thenReturn(expectedBEList);
-        when(dsbMannschaftDAO.findAllByWettkampfId(WETTKAMPF_ID+1)).thenReturn(null);
+        when(dsbMannschaftDAOext.findAllByWettkampfId(WETTKAMPF_ID)).thenReturn(expectedBEList);
+        when(dsbMannschaftDAOext.findAllByWettkampfId(WETTKAMPF_ID+1)).thenReturn(null);
 
         // call test method
         final List<DsbMannschaftDO> actual = underTest.findAllByWettkampfId(WETTKAMPF_ID);
@@ -327,7 +327,7 @@ public class DsbMannschaftComponentImplTest {
 
 
         // verify invocations
-        verify(dsbMannschaftDAO).findAllByWettkampfId(WETTKAMPF_ID);
+        verify(dsbMannschaftDAOext).findAllByWettkampfId(WETTKAMPF_ID);
         verify(vereinComponent).findById(anyLong());
     }
 
@@ -412,12 +412,12 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void findVeranstaltungAndWettkampfById() {
         // prepare test data
-        final DsbMannschaftBE expectedBE = getDsbMannschaftBEVERANDWETT();
-        final List<DsbMannschaftBE> expectedBEList = Collections.singletonList(expectedBE);
+        final DsbMannschaftBEext expectedBE = getDsbMannschaftBEext();
+        final List<DsbMannschaftBEext> expectedBEList = Collections.singletonList(expectedBE);
         expectedBE.setVeranstaltungId(null);
 
         // configure mocks
-        when(dsbMannschaftDAO.findVeranstaltungAndWettkampfById(VEREIN_ID)).thenReturn(expectedBEList);
+        when(dsbMannschaftDAOext.findVeranstaltungAndWettkampfById(VEREIN_ID)).thenReturn(expectedBEList);
 
         // call test method
         final List<DsbMannschaftDO> actual = underTest.findVeranstaltungAndWettkampfByID(VEREIN_ID);
@@ -430,8 +430,8 @@ public class DsbMannschaftComponentImplTest {
 
         assertThat(actual.get(0)).isNotNull();
 
-        Assertions.assertThat(actual.get(0).getMannschaft_nummer())
-                .isEqualTo(expectedBE.getMannschaftNummer());
+        Assertions.assertThat(actual.get(0).getNummer())
+                .isEqualTo(expectedBE.getNummer());
         Assertions.assertThat(actual.get(0).getVerein_name())
                 .isEqualTo(expectedBE.getVereinName());
         Assertions.assertThat(actual.get(0).getWettkampf_ortsname())
@@ -442,7 +442,7 @@ public class DsbMannschaftComponentImplTest {
                 .isEqualTo(expectedBE.getVeranstaltungName());
 
         // verify invocations
-        verify(dsbMannschaftDAO).findVeranstaltungAndWettkampfById(VEREIN_ID);
+        verify(dsbMannschaftDAOext).findVeranstaltungAndWettkampfById(VEREIN_ID);
     }
     private static final long VALID_ID = 1L;
     private static final long INVALID_ID = -1L;
@@ -452,7 +452,7 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void findEverythingById_shouldThrowException_whenResultIsNull() {
         // Arrange
-        when(dsbMannschaftDAO.findVeranstaltungAndWettkampfById(VALID_ID)).thenReturn(null);
+        when(dsbMannschaftDAOext.findVeranstaltungAndWettkampfById(VALID_ID)).thenReturn(null);
 
         // Act & Assert
         try {
@@ -465,7 +465,7 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void findEverythingById_shouldReturnEmptyList_whenResultIsEmpty() {
         // Arrange
-        when(dsbMannschaftDAO.findVeranstaltungAndWettkampfById(VALID_ID)).thenReturn(Collections.emptyList());
+        when(dsbMannschaftDAOext.findVeranstaltungAndWettkampfById(VALID_ID)).thenReturn(Collections.emptyList());
 
         // Act
         List<DsbMannschaftDO> actual = underTest.findVeranstaltungAndWettkampfByID(VALID_ID);
@@ -965,11 +965,11 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void findEverything(){
         // prepare test data
-        final DsbMannschaftBE expectedBE = getDsbMannschaftBEVERANDWETT();
-        final List<DsbMannschaftBE> expectedBEList = Collections.singletonList(expectedBE);
+        final DsbMannschaftBEext expectedBE = getDsbMannschaftBEext();
+        final List<DsbMannschaftBEext> expectedBEList = Collections.singletonList(expectedBE);
 
         // configure mocks
-        when(dsbMannschaftDAO.findVeranstaltungAndWettkampfById(VEREIN_ID)).thenReturn(expectedBEList);
+        when(dsbMannschaftDAOext.findVeranstaltungAndWettkampfById(VEREIN_ID)).thenReturn(expectedBEList);
 
         // call test method
         final List<DsbMannschaftDO> actual = underTest.findVeranstaltungAndWettkampfByID(VEREIN_ID);
@@ -982,8 +982,8 @@ public class DsbMannschaftComponentImplTest {
 
         assertThat(actual.get(0)).isNotNull();
 
-        Assertions.assertThat(actual.get(0).getMannschaft_nummer())
-                .isEqualTo(expectedBE.getMannschaftNummer());
+        Assertions.assertThat(actual.get(0).getNummer())
+                .isEqualTo(expectedBE.getNummer());
         Assertions.assertThat(actual.get(0).getVerein_name())
                 .isEqualTo(expectedBE.getVereinName());
         Assertions.assertThat(actual.get(0).getWettkampf_ortsname())
@@ -995,7 +995,7 @@ public class DsbMannschaftComponentImplTest {
 
 
         // verify invocations
-        verify(dsbMannschaftDAO).findVeranstaltungAndWettkampfById(VEREIN_ID);
+        verify(dsbMannschaftDAOext).findVeranstaltungAndWettkampfById(VEREIN_ID);
     }
     @Test
     public void fillName_VereinNull(){
@@ -1088,6 +1088,7 @@ public class DsbMannschaftComponentImplTest {
         assertThat(mannschaftsmitgliedDOArgumentCaptor.getValue().getMannschaftId()).isEqualTo(newMannschaftId);
     }
     private DsbMannschaftBE dsbMannschaft;
+    private DsbMannschaftBEext dsbMannschaftext;
     @Test
     public void testGetAndSetId() {
         dsbMannschaft = new DsbMannschaftBE();
@@ -1138,42 +1139,42 @@ public class DsbMannschaftComponentImplTest {
 
     @Test
     public void testGetAndSetVeranstaltungName() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String veranstaltungName = "Meisterschaft";
-        dsbMannschaft.setVeranstaltungName(veranstaltungName);
-        assertThat(dsbMannschaft.getVeranstaltungName()).isEqualTo(veranstaltungName);
+        dsbMannschaftext.setVeranstaltungName(veranstaltungName);
+        assertThat(dsbMannschaftext.getVeranstaltungName()).isEqualTo(veranstaltungName);
     }
 
     @Test
     public void testGetAndSetWettkampfTag() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String wettkampfTag = "2024-07-22";
-        dsbMannschaft.setWettkampfTag(wettkampfTag);
-        assertThat(dsbMannschaft.getWettkampfTag()).isEqualTo(wettkampfTag);
+        dsbMannschaftext.setWettkampfTag(wettkampfTag);
+        assertThat(dsbMannschaftext.getWettkampfTag()).isEqualTo(wettkampfTag);
     }
 
     @Test
     public void testGetAndSetWettkampfOrtsname() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String wettkampfOrtsname = "Berlin";
-        dsbMannschaft.setWettkampfOrtsname(wettkampfOrtsname);
-        assertThat(dsbMannschaft.getWettkampfOrtsname()).isEqualTo(wettkampfOrtsname);
+        dsbMannschaftext.setWettkampfOrtsname(wettkampfOrtsname);
+        assertThat(dsbMannschaftext.getWettkampfOrtsname()).isEqualTo(wettkampfOrtsname);
     }
 
     @Test
     public void testGetAndSetVereinName() {
-        dsbMannschaft = new DsbMannschaftBE();
+        dsbMannschaftext = new DsbMannschaftBEext();
         String vereinName = "Sportverein Berlin";
-        dsbMannschaft.setVereinName(vereinName);
-        assertThat(dsbMannschaft.getVereinName()).isEqualTo(vereinName);
+        dsbMannschaftext.setVereinName(vereinName);
+        assertThat(dsbMannschaftext.getVereinName()).isEqualTo(vereinName);
     }
 
     @Test
     public void testGetAndSetMannschaftNummer() {
         dsbMannschaft = new DsbMannschaftBE();
         Long mannschaftNummer = 12345L;
-        dsbMannschaft.setMannschaftNummer(mannschaftNummer);
-        assertThat(dsbMannschaft.getMannschaftNummer()).isEqualTo(mannschaftNummer);
+        dsbMannschaft.setNummer(mannschaftNummer);
+        assertThat(dsbMannschaft.getNummer()).isEqualTo(mannschaftNummer);
     }
     private DsbMannschaftDO dsbMannschaftDO;
     @Test
@@ -1255,12 +1256,4 @@ public class DsbMannschaftComponentImplTest {
         dsbMannschaftDO.setVerein_name(vereinName);
         assertThat(dsbMannschaftDO.getVerein_name()).isEqualTo(vereinName);
     }
-
-    @Test
-    public void testGetAndSetMannschaftNummerDO() {
-        dsbMannschaftDO= new DsbMannschaftDO();
-        Long mannschaftNummer = 12345L;
-        dsbMannschaftDO.setMannschaft_nummer(mannschaftNummer);
-        assertThat(dsbMannschaftDO.getMannschaft_nummer()).isEqualTo(mannschaftNummer);
-    }
-}
+ }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -95,9 +95,7 @@ public class DsbMannschaftComponentImplTest {
     }
     public static DsbMannschaftBEext getDsbMannschaftBEext() {
         DsbMannschaftBEext dsbMannschaftBE = new DsbMannschaftBEext(ID, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID,
-                SORTIERUNG, SPORTJAHR, VERANSTALTUNGNAME,
-                WETTKAMPTAG,
-                WETTKAMPFORT, VEREINNAME);
+                SORTIERUNG, SPORTJAHR, VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
 
         return dsbMannschaftBE ;
     }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -52,7 +52,6 @@ public class DsbMannschaftComponentImplTest {
     private static final String VEREINNAME ="SSV REUTLINGEN";
     private static final String WETTKAMPFORT ="SSV REUTLINGEN";
     private static final String WETTKAMPTAG ="1";
-    private static final long MANNSCHAFTNUMMER = 0;
     private static final long DB_SORTIERUNG =0L;
     private static final long SPORTJAHR =2024L;
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -94,7 +94,13 @@ public class DsbMannschaftComponentImplTest {
     }
     public static DsbMannschaftBEext getDsbMannschaftBEext() {
         DsbMannschaftBEext dsbMannschaftBE = new DsbMannschaftBEext(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
-        dsbMannschaftBE.setNummer(MANNSCHAFTNUMMER);
+        dsbMannschaftBE.setId(ID);
+        dsbMannschaftBE.setVereinId(VEREIN_ID);
+        dsbMannschaftBE.setNummer(NUMMER);
+        dsbMannschaftBE.setBenutzerId(BENUTZER_ID);
+        dsbMannschaftBE.setVeranstaltungId(VERANSTALTUNG_ID);
+        dsbMannschaftBE.setSortierung(SORTIERUNG);
+
         return dsbMannschaftBE ;
     }
     public static DsbMannschaftDO getDsbMannschaftDO() {

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -94,14 +94,10 @@ public class DsbMannschaftComponentImplTest {
         return expectedBE;
     }
     public static DsbMannschaftBEext getDsbMannschaftBEext() {
-        DsbMannschaftBEext dsbMannschaftBE = new DsbMannschaftBEext(VERANSTALTUNGNAME, WETTKAMPTAG, WETTKAMPFORT, VEREINNAME);
-        dsbMannschaftBE.setId(ID);
-        dsbMannschaftBE.setVereinId(VEREIN_ID);
-        dsbMannschaftBE.setNummer(NUMMER);
-        dsbMannschaftBE.setBenutzerId(BENUTZER_ID);
-        dsbMannschaftBE.setVeranstaltungId(VERANSTALTUNG_ID);
-        dsbMannschaftBE.setSortierung(SORTIERUNG);
-        dsbMannschaftBE.setSportjahr(SPORTJAHR);
+        DsbMannschaftBEext dsbMannschaftBE = new DsbMannschaftBEext(ID, VEREIN_ID, NUMMER, BENUTZER_ID, VERANSTALTUNG_ID,
+                SORTIERUNG, SPORTJAHR, VERANSTALTUNGNAME,
+                WETTKAMPTAG,
+                WETTKAMPFORT, VEREINNAME);
 
         return dsbMannschaftBE ;
     }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -390,10 +390,10 @@ public class DsbMannschaftComponentImplTest {
         expectedBE.setVeranstaltungId(null);
 
         // configure mocks
-        when(dsbMannschaftDAO.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID)).thenReturn(expectedBEList);
+        when(dsbMannschaftDAO.findAllByWarteschlange()).thenReturn(expectedBEList);
 
         // call test method
-        final List<DsbMannschaftDO> actual = underTest.findAllByWarteschlange(CURRENT_VERANSTALTUNG_ID);
+        final List<DsbMannschaftDO> actual = underTest.findAllByWarteschlange();
 
         // assert result
         assertThat(actual)
@@ -418,7 +418,7 @@ public class DsbMannschaftComponentImplTest {
 
 
         // verify invocations
-        verify(dsbMannschaftDAO).findAllByWarteschlange(anyLong());
+        verify(dsbMannschaftDAO).findAllByWarteschlange();
         verify(vereinComponent).findById(anyLong());
     }
     @Test
@@ -606,7 +606,7 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void create_withoutInput_shouldThrowException() {
         // prepare test data
-        DsbMannschaftDO tmpMannschaft = new DsbMannschaftDO(ID,-1);
+        DsbMannschaftDO tmpMannschaft = new DsbMannschaftDO(ID,-1L);
 
         // configure mocks
 
@@ -627,21 +627,21 @@ public class DsbMannschaftComponentImplTest {
                 .withNoCause();
         tmpMannschaft.setVereinId(VEREIN_ID);
 
-        tmpMannschaft.setNummer(-1);
+        tmpMannschaft.setNummer(-1L);
         assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> underTest.create(tmpMannschaft, USER))
                 .withMessageContaining("must not be negative")
                 .withNoCause();
         tmpMannschaft.setNummer(NUMMER);
 
-        tmpMannschaft.setBenutzerId(-1);
+        tmpMannschaft.setBenutzerId(-1L);
         assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> underTest.create(tmpMannschaft, USER))
                 .withMessageContaining("must not be negative")
                 .withNoCause();
         tmpMannschaft.setBenutzerId(BENUTZER_ID);
 
-        tmpMannschaft.setVereinId(-1);
+        tmpMannschaft.setVereinId(-1L);
         assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(() -> underTest.create(tmpMannschaft, USER))
                 .withMessageContaining("must not be negative")
@@ -718,7 +718,7 @@ public class DsbMannschaftComponentImplTest {
     @Test
     public void update_withoutInput_shouldThrowException() {
         // prepare test data
-        DsbMannschaftDO tmpMannschaft = new DsbMannschaftDO(ID,-1);
+        DsbMannschaftDO tmpMannschaft = new DsbMannschaftDO(ID,-1L);
 
         // configure mocks
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
@@ -134,74 +134,7 @@ public class DsbMannschaftBasicDAOTest {
 
     }
 
-    @Test
-    public void findAllByWettkampfId() {
-        // prepare test data
-        final DsbMannschaftBE expectedBE = getDsbMannschaftBE();
-
-        // configure mocks
-        when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
-
-        // call test method
-        final List<DsbMannschaftBE> actual = underTest.findAllByWettkampfId(wettkampfId);
-
-        // assert result
-        assertThat(actual)
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1);
-
-        assertThat(actual.get(0)).isNotNull();
-
-        assertThat(actual.get(0).getId())
-                .isEqualTo(expectedBE.getId());
-        assertThat(actual.get(0).getVereinId())
-                .isEqualTo(expectedBE.getVereinId());
-        assertThat(actual.get(0).getNummer())
-                .isEqualTo(expectedBE.getNummer());
-        assertThat(actual.get(0).getVeranstaltungId())
-                .isEqualTo(expectedBE.getVeranstaltungId());
-
-        // verify invocations
-        verify(basicDao).selectEntityList(any(), any(), any());
-    }
-    @Test
-    public void findVeranstaltungAndWettkampfById() {
-        // prepare test data
-        final DsbMannschaftBE expectedBE = getDsbMannschaftBE();
-
-        // configure mocks
-        when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
-        expectedBE.setVeranstaltungId(null);
-
-        // call test method
-        final List<DsbMannschaftBE> actual = underTest.findAllByWarteschlange();
-
-        // assert result
-        assertThat(actual)
-                .isNotNull()
-                .isNotEmpty()
-                .hasSize(1);
-
-        assertThat(actual.get(0)).isNotNull();
-
-        assertThat(actual.get(0).getMannschaftNummer())
-                .isEqualTo(expectedBE.getMannschaftNummer());
-        assertThat(actual.get(0).getVereinName())
-                .isEqualTo(expectedBE.getVereinName());
-        assertThat(actual.get(0).getWettkampfOrtsname())
-                .isEqualTo(expectedBE.getWettkampfOrtsname());
-        assertThat(actual.get(0).getWettkampfTag())
-                .isEqualTo(expectedBE.getWettkampfTag());
-        assertThat(actual.get(0).getVeranstaltungName())
-                .isEqualTo(expectedBE.getVeranstaltungName());
-
-        // verify invocations
-        verify(basicDao).selectEntityList(any(), any(), any());
-
-
-    }
-    @Test
+     @Test
     public void findAllByWarteschlange() {
         // prepare test data
         final DsbMannschaftBE expectedBE = getDsbMannschaftBE();

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
@@ -144,7 +144,7 @@ public class DsbMannschaftBasicDAOTest {
         expectedBE.setVeranstaltungId(null);
 
         // call test method
-        final List<DsbMannschaftBE> actual = underTest.findAllByWarteschlange();
+        final List<DsbMannschaftBE> actual = underTest.findAllByWarteschlange(veranstaltungId);
 
         // assert result
         assertThat(actual)

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
@@ -144,7 +144,7 @@ public class DsbMannschaftBasicDAOTest {
         expectedBE.setVeranstaltungId(null);
 
         // call test method
-        final List<DsbMannschaftBE> actual = underTest.findAllByWarteschlange(veranstaltungId);
+        final List<DsbMannschaftBE> actual = underTest.findAllByWarteschlange();
 
         // assert result
         assertThat(actual)

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOTest.java
@@ -27,9 +27,7 @@ public class DsbMannschaftBasicDAOTest {
     private static final long id = 2222L;
     private static final long vereinId=101010;
     private static final long nummer=111;
-    private static final long benutzerId=12;
     private static final long veranstaltungId=1;
-    private static final long wettkampfId=31;
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOextTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOextTest.java
@@ -1,0 +1,110 @@
+package de.bogenliga.application.business.dsbmannschaft.impl.dao;
+
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
+import de.bogenliga.application.common.component.dao.BasicDAO;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import static de.bogenliga.application.business.dsbmannschaft.impl.business.DsbMannschaftComponentImplTest.getDsbMannschaftBEext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DsbMannschaftBasicDAOextTest {
+
+    private static final Long USER = 0L;
+    private static final Long VERSION = 0L;
+
+    private static final long id = 2222L;
+    private static final long vereinId=101010;
+    private static final long nummer=111;
+    private static final long benutzerId=12;
+    private static final long veranstaltungId=1;
+    private static final long wettkampfId=31;
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private BasicDAO basicDao;
+    @InjectMocks
+    private DsbMannschaftDAOext underTest;
+
+
+    @Test
+    public void findAllByWettkampfId() {
+        // prepare test data
+        final DsbMannschaftBEext expectedBE = getDsbMannschaftBEext();
+
+        // configure mocks
+        when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+        // call test method
+        final List<DsbMannschaftBEext> actual = underTest.findAllByWettkampfId(wettkampfId);
+
+        // assert result
+        assertThat(actual)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(actual.get(0)).isNotNull();
+
+        assertThat(actual.get(0).getId())
+                .isEqualTo(expectedBE.getId());
+        assertThat(actual.get(0).getVereinId())
+                .isEqualTo(expectedBE.getVereinId());
+        assertThat(actual.get(0).getNummer())
+                .isEqualTo(expectedBE.getNummer());
+        assertThat(actual.get(0).getVeranstaltungId())
+                .isEqualTo(expectedBE.getVeranstaltungId());
+
+        // verify invocations
+        verify(basicDao).selectEntityList(any(), any(), any());
+    }
+    @Test
+    public void findVeranstaltungAndWettkampfById() {
+        // prepare test data
+        final DsbMannschaftBEext expectedBE = getDsbMannschaftBEext();
+
+        // configure mocks
+        when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+        expectedBE.setVeranstaltungId(null);
+
+        // call test method
+        final List<DsbMannschaftBEext> actual = underTest.findVeranstaltungAndWettkampfById(wettkampfId);
+
+        // assert result
+        assertThat(actual)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(actual.get(0)).isNotNull();
+
+        assertThat(actual.get(0).getNummer())
+                .isEqualTo(expectedBE.getNummer());
+        assertThat(actual.get(0).getVereinName())
+                .isEqualTo(expectedBE.getVereinName());
+        assertThat(actual.get(0).getWettkampfOrtsname())
+                .isEqualTo(expectedBE.getWettkampfOrtsname());
+        assertThat(actual.get(0).getWettkampfTag())
+                .isEqualTo(expectedBE.getWettkampfTag());
+        assertThat(actual.get(0).getVeranstaltungName())
+                .isEqualTo(expectedBE.getVeranstaltungName());
+
+        // verify invocations
+        verify(basicDao).selectEntityList(any(), any(), any());
+
+
+    }
+
+}

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOextTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftBasicDAOextTest.java
@@ -15,20 +15,11 @@ import java.util.List;
 import static de.bogenliga.application.business.dsbmannschaft.impl.business.DsbMannschaftComponentImplTest.getDsbMannschaftBEext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DsbMannschaftBasicDAOextTest {
 
-    private static final Long USER = 0L;
-    private static final Long VERSION = 0L;
-
-    private static final long id = 2222L;
-    private static final long vereinId=101010;
-    private static final long nummer=111;
-    private static final long benutzerId=12;
-    private static final long veranstaltungId=1;
     private static final long wettkampfId=31;
 
     @Rule

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/mapper/DsbMannschaftMapperTest.java
@@ -3,6 +3,7 @@ package de.bogenliga.application.business.dsbmannschaft.impl.mapper;
 import org.junit.Test;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBE;
+import de.bogenliga.application.business.dsbmannschaft.impl.entity.DsbMannschaftBEext;
 import static de.bogenliga.application.business.dsbmannschaft.impl.business.DsbMannschaftComponentImplTest.getDsbMannschaftBE;
 import static de.bogenliga.application.business.dsbmannschaft.impl.business.DsbMannschaftComponentImplTest.getDsbMannschaftDO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,21 +42,31 @@ public class DsbMannschaftMapperTest {
     @Test
     public void toDsbMannschaftVerUWettDO() {
         // Arrange
-        DsbMannschaftBE dsbMannschaftBE = new DsbMannschaftBE();
-        dsbMannschaftBE.setVeranstaltungName("Olympia");
-        dsbMannschaftBE.setWettkampfTag("2024-08-01");
-        dsbMannschaftBE.setWettkampfOrtsname("Berlin");
-        dsbMannschaftBE.setVereinName("Sportverein Berlin");
-        dsbMannschaftBE.setMannschaftNummer(12345L);
-        dsbMannschaftBE.setNummer(12345L);
+        DsbMannschaftBEext dsbMannschaftBEext = new DsbMannschaftBEext();
+        dsbMannschaftBEext.setId(ID);
+        dsbMannschaftBEext.setVereinId(VEREINID);
+        dsbMannschaftBEext.setNummer(NUMMER);
+        dsbMannschaftBEext.setBenutzerId(BENUTZERID);
+        dsbMannschaftBEext.setVeranstaltungId(VERANSTALTUNGID);
+        dsbMannschaftBEext.setVeranstaltungName("Olympia");
+
+        dsbMannschaftBEext.setVeranstaltungName("Olympia");
+        dsbMannschaftBEext.setWettkampfTag("2024-08-01");
+        dsbMannschaftBEext.setWettkampfOrtsname("Berlin");
+        dsbMannschaftBEext.setVereinName("Sportverein Berlin");
         // Act
-        DsbMannschaftDO dsbMannschaftDO = DsbMannschaftMapper.toDsbMannschaftVerUWettDO.apply(dsbMannschaftBE);
+        DsbMannschaftDO dsbMannschaftDO = DsbMannschaftMapper.toDsbMannschaftVerUWettDO.apply(dsbMannschaftBEext);
 
         // Assert
+        assertThat(dsbMannschaftDO.getId()).isEqualTo(ID);
+        assertThat(dsbMannschaftDO.getVereinId()).isEqualTo(VEREINID);
+        assertThat(dsbMannschaftDO.getNummer()).isEqualTo(NUMMER);
+        assertThat(dsbMannschaftDO.getBenutzerId()).isEqualTo(BENUTZERID);
+        assertThat(dsbMannschaftDO.getName()).isEqualTo("Sportverein Berlin"+NUMMER);
         assertThat(dsbMannschaftDO.getVeranstaltung_name()).isEqualTo("Olympia");
         assertThat(dsbMannschaftDO.getWettkampfTag()).isEqualTo("2024-08-01");
         assertThat(dsbMannschaftDO.getWettkampf_ortsname()).isEqualTo("Berlin");
         assertThat(dsbMannschaftDO.getVerein_name()).isEqualTo("Sportverein Berlin");
-        assertThat(dsbMannschaftDO.getMannschaft_nummer()).isEqualTo(12345L);
+        assertThat(dsbMannschaftDO.getNummer()).isEqualTo(NUMMER);
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/match/impl/BaseMatchTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/match/impl/BaseMatchTest.java
@@ -57,7 +57,7 @@ public abstract class BaseMatchTest {
 
     protected DsbMannschaftDO getPlatzhalter() {
         return new DsbMannschaftDO(
-                MATCH_MANNSCHAFT_ID, "Platzhalter", MATCH_PLATZHALTER_ID, 696969L, 01274L, 4444L, 8L
+                MATCH_MANNSCHAFT_ID, "Platzhalter", MATCH_PLATZHALTER_ID, 696969L, 01274L, 4444L, 8L, 2024L
         );
     }
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/match/impl/business/MatchComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/match/impl/business/MatchComponentImplTest.java
@@ -88,7 +88,9 @@ public class MatchComponentImplTest extends BaseMatchTest {
                 99L,
                 0L,
                 444L,
-                8L);
+                8L,
+                2024L);
+
     }
 
     public static VereinDO getVereinDO() {
@@ -615,7 +617,7 @@ public class MatchComponentImplTest extends BaseMatchTest {
             List<DsbMannschaftDO> mannschaften = new ArrayList<>();
 
             for (int i = 0; i < numberOfTeams; i++) {
-                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L);
+                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L, 1L);
                 mannschaften.add(mannschaft);
             }
 
@@ -638,7 +640,7 @@ public class MatchComponentImplTest extends BaseMatchTest {
             List<DsbMannschaftDO> mannschaften = new ArrayList<>();
 
             for (int i = 0; i < numberOfTeams; i++) {
-                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L);
+                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L, 1L);
                 mannschaften.add(mannschaft);
             }
 
@@ -661,7 +663,7 @@ public class MatchComponentImplTest extends BaseMatchTest {
             List<DsbMannschaftDO> mannschaften = new ArrayList<>();
 
             for (int i = 0; i < numberOfTeams; i++) {
-                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L);
+                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L, 1L);
                 mannschaften.add(mannschaft);
             }
 
@@ -684,7 +686,7 @@ public class MatchComponentImplTest extends BaseMatchTest {
             List<DsbMannschaftDO> mannschaften = new ArrayList<>();
 
             for (int i = 0; i < numberOfTeams; i++) {
-                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L);
+                DsbMannschaftDO mannschaft = new DsbMannschaftDO(1L, "TEST", 1L, 1L, 1L, 1L, 1L, 1L);
                 mannschaften.add(mannschaft);
             }
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
@@ -275,7 +275,7 @@ public class WettkampfComponentImplTest {
     public static DsbMannschaftDO getDsbMannschaftDO()
     {
         DsbMannschaftDO neueMannschaft = new DsbMannschaftDO(1l,"1.Manschaft Muster Hausen",1l,1l,
-                0l,wettkampf_Veranstaltung_Id,0l);
+                0l,wettkampf_Veranstaltung_Id,0l, 1L);
         return neueMannschaft;
     }
 


### PR DESCRIPTION
Bugfix um in dem Dialog Veranstaltung-Detail Mannschaften einer Liga hinzufügen und entfernen zu können.
https://gitlab.gras-it.de/hsrt/swt2/-/issues/1730; Zusätzlich Anzeige des Sportjahres im Dialog Verein Details.