### PR TITLE
added SchuetzeStammDaten enrichment during Schützenmeldung to not use…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/TabletSchusszettelComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/TabletSchusszettelComponentImpl.java
@@ -438,6 +438,20 @@ public class TabletSchusszettelComponentImpl implements TabletSchusszettelCompon
                                         TabletSchusszettelDO out,
                                         long teamId) {
         List<MannschaftsmitgliedDO> members = mmComponent.findByTeamId(teamId);
+
+        // Stammdaten aller Vereins-Schützen zusammenstellen
+        List<SchuetzeStammdatenDO> stammdaten = members.stream()
+                .map(m -> {
+                    DsbMitgliedDO dm = mitgliedComponent.findById(m.getDsbMitgliedId());
+                    return new SchuetzeStammdatenDO(
+                            dm.getId(),
+                            Math.toIntExact(m.getRueckennummer()),
+                            dm.getVorname(),
+                            dm.getNachname()
+                    );
+                }).collect(Collectors.toList());
+        out.setSchuetzeStammDaten(stammdaten);
+
         List<VerfuegbarerSchuetzeDO> available = members.stream()
                 .map(m -> {
                     DsbMitgliedDO dm = mitgliedComponent.findById(m.getDsbMitgliedId());


### PR DESCRIPTION
This pull request introduces a change to the `handleSchuetzenmeldung` method in `TabletSchusszettelComponentImpl.java`. The update adds functionality to compile and set the "stammdaten" (master data) of all club shooters into the `TabletSchusszettelDO` object.

### Key change:
* **Enhancement to shooter data handling:**
  - Added logic to create a list of `SchuetzeStammdatenDO` objects from team members, including their ID,rückennummer, first name, and last name. This list is then set into the `TabletSchusszettelDO` object via the `setSchuetzeStammDaten` method.