### PR TITLE
Clean Code - Konstanten in Großbuchstaben schreiben... Ticket #1845

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/kampfrichter/impl/entity/KampfrichterExtendedBETest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/kampfrichter/impl/entity/KampfrichterExtendedBETest.java
@@ -25,7 +25,7 @@ public class KampfrichterExtendedBETest extends TestCase {
     private static final String EMAIL = "max.mustermann@test.de";
 
     // Test data for setters
-    private static final Long nUSERID = 2L;
+    private static final Long N_USER_ID = 2L;
     private static final Long nWETTKAMPFID = 888L;
     private static final Boolean nLEITEND = true;
     private static final String nVORNAME = "Kaede";
@@ -67,8 +67,8 @@ public class KampfrichterExtendedBETest extends TestCase {
 
     @Test
     public void testSetKampfrichterExtendedUserID() {
-        Long expected = nUSERID;
-        underTest.setKampfrichterExtendedUserID(nUSERID);
+        Long expected = N_USER_ID;
+        underTest.setKampfrichterExtendedUserID(N_USER_ID);
         Long actual = underTest.getKampfrichterExtendedUserID();
 
         assertEquals(expected, actual);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/ligatabelle/api/types/LigatabelleDOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/ligatabelle/api/types/LigatabelleDOTest.java
@@ -29,7 +29,7 @@ public class LigatabelleDOTest extends TestCase {
     private static int sortierung = 0;
     private static int tabellenplatz = 8;
 
-    private static final int matchCount = 0;
+    private static final int MATCH_COUNT = 0;
 
 
     @Rule
@@ -55,7 +55,7 @@ public class LigatabelleDOTest extends TestCase {
         expectedLigatabelleDO.setSatzpktDifferenz(satzpktDifferenz);
         expectedLigatabelleDO.setsortierung(sortierung);
         expectedLigatabelleDO.settabellenplatz(tabellenplatz);
-        expectedLigatabelleDO.setMatchCount(matchCount);
+        expectedLigatabelleDO.setMatchCount(MATCH_COUNT);
 
 
         return expectedLigatabelleDO;

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/lizenz/impl/business/LizenzComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/lizenz/impl/business/LizenzComponentImplTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
 
 public class LizenzComponentImplTest {
 
-    private static final long lizenzId = 0;
+    private static final long LIZENZ_ID = 0;
     private static final String lizenznummer = "WT1234567";
     private static final long lizenzRegionId = 1;
     private static final long lizenzDsbMitgliedId = 1337L;
@@ -81,7 +81,7 @@ public class LizenzComponentImplTest {
 
     public static LizenzBE getLizenzBE() {
         final LizenzBE expectedBE = new LizenzBE();
-        expectedBE.setLizenzId(lizenzId);
+        expectedBE.setLizenzId(LIZENZ_ID);
         expectedBE.setLizenznummer(lizenznummer);
         expectedBE.setLizenzRegionId(lizenzRegionId);
         expectedBE.setLizenzDisziplinId(lizenzDisziplinId);
@@ -93,7 +93,7 @@ public class LizenzComponentImplTest {
 
 
     public static LizenzDO getLizenzDO() {
-        return new LizenzDO(lizenzId,
+        return new LizenzDO(LIZENZ_ID,
                 lizenznummer,
                 lizenzRegionId,
                 lizenzDsbMitgliedId,
@@ -217,7 +217,7 @@ public class LizenzComponentImplTest {
     public void create() {
         // prepare test data
         final LizenzDO input = new LizenzDO();
-        input.setLizenzId(lizenzId);
+        input.setLizenzId(LIZENZ_ID);
         input.setLizenztyp("Liga");
         input.setLizenznummer("WT012354");
         input.setLizenzRegionId(1L);
@@ -225,14 +225,14 @@ public class LizenzComponentImplTest {
         input.setLizenzDisziplinId(1L);
 
         final LizenzBE lizenzBE = new LizenzBE();
-        lizenzBE.setLizenzId(lizenzId);
+        lizenzBE.setLizenzId(LIZENZ_ID);
         lizenzBE.setLizenzDsbMitgliedId(lizenzDsbMitgliedId);
 
         // configure mocks
         when(lizenzDAO.create(any(LizenzBE.class), anyLong())).thenReturn(lizenzBE);
 
         // call test method
-        final LizenzDO actual = underTest.create(input, lizenzId);
+        final LizenzDO actual = underTest.create(input, LIZENZ_ID);
 
         // assert result
         Assertions.assertThat(actual).isNotNull();
@@ -251,7 +251,7 @@ public class LizenzComponentImplTest {
     public void update() {
         // prepare test data
         final LizenzDO input = new LizenzDO();
-        input.setLizenzId(lizenzId);
+        input.setLizenzId(LIZENZ_ID);
         input.setLizenztyp("Liga");
         input.setLizenznummer("WT012354");
         input.setLizenzRegionId(1L);
@@ -259,14 +259,14 @@ public class LizenzComponentImplTest {
         input.setLizenzDisziplinId(1L);
 
         final LizenzBE lizenzBE = new LizenzBE();
-        lizenzBE.setLizenzId(lizenzId);
+        lizenzBE.setLizenzId(LIZENZ_ID);
         lizenzBE.setLizenzDsbMitgliedId(lizenzDsbMitgliedId);
 
         // configure mocks
         when(lizenzDAO.update(any(LizenzBE.class), anyLong())).thenReturn(lizenzBE);
 
         // call test method
-        final LizenzDO actual = underTest.update(input, lizenzId);
+        final LizenzDO actual = underTest.update(input, LIZENZ_ID);
 
         // assert result
         Assertions.assertThat(actual).isNotNull();

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/mannschaftsmitglied/impl/business/MannschaftsmitgliedComponentImplTest.java
@@ -38,7 +38,7 @@ public class MannschaftsmitgliedComponentImplTest {
     private static final Long DSB_MITGLIED_ID = 2222L;
     private static final Integer DSB_MITGLIED_EINGESETZT = 1;
     private static final String DSB_MITGLIED_VORNSME = "Mario";
-    private static final String DSB_MItglied_Nachname = "Gomez";
+    private static final String DSB_MITGLIED_NACHNAME = "Gomez";
     private static final Long RUECKENNUMMER = 5L;
     private static final Long WETTKAMPFID = 11L;
 
@@ -75,7 +75,7 @@ public class MannschaftsmitgliedComponentImplTest {
                 DSB_MITGLIED_ID,
                 DSB_MITGLIED_EINGESETZT,
                 DSB_MITGLIED_VORNSME,
-                DSB_MItglied_Nachname,
+                DSB_MITGLIED_NACHNAME,
                 RUECKENNUMMER);
     }
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/api/types/SchuetzenstatistikDOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/api/types/SchuetzenstatistikDOTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoRule;
 import static org.junit.Assert.*;
 
 public class SchuetzenstatistikDOTest {
-    private static final Long veranstaltungId = 1L;
+    private static final Long VERANSTALTUNG_ID = 1L;
     private static final String veranstaltungName = "Name_der_Veranstaltung";
     private static final Long wettkampfId = 2L;
     private static final int wettkampfTag = 3;
@@ -35,7 +35,7 @@ public class SchuetzenstatistikDOTest {
     //create a SchuetzenstatistikDO-Object for the test with values
     public static SchuetzenstatistikDO getSchuetzenstatistikDO() {
         final SchuetzenstatistikDO expectedSchuetzenstatistikDO = new SchuetzenstatistikDO();
-        expectedSchuetzenstatistikDO.setveranstaltungId(veranstaltungId);
+        expectedSchuetzenstatistikDO.setveranstaltungId(VERANSTALTUNG_ID);
         expectedSchuetzenstatistikDO.setveranstaltungName(veranstaltungName);
         expectedSchuetzenstatistikDO.setwettkampfId(wettkampfId);
         expectedSchuetzenstatistikDO.setwettkampfTag(wettkampfTag);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/impl/business/SchuetzenstatistikComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/impl/business/SchuetzenstatistikComponentImplTest.java
@@ -26,7 +26,7 @@ public class SchuetzenstatistikComponentImplTest {
     private static final Long USER = 0L;
     private static final Long VERSION = 0L;
 
-    private static final Long veranstaltungId = 1L;
+    private static final Long VERANSTALTUNG_ID = 1L;
     private static final String veranstaltungName = "Name_der_Veranstaltung";
     private static final Long wettkampfId = 2L;
     private static final int wettkampfTag = 3;
@@ -60,7 +60,7 @@ public class SchuetzenstatistikComponentImplTest {
 
     public static SchuetzenstatistikBE getSchuetzenstatistikBE() {
         final SchuetzenstatistikBE expectedSchuetzenstatistikBE = new SchuetzenstatistikBE();
-        expectedSchuetzenstatistikBE.setVeranstaltungId(veranstaltungId);
+        expectedSchuetzenstatistikBE.setVeranstaltungId(VERANSTALTUNG_ID);
         expectedSchuetzenstatistikBE.setVeranstaltungName(veranstaltungName);
         expectedSchuetzenstatistikBE.setWettkampfId(wettkampfId);
         expectedSchuetzenstatistikBE.setWettkampfTag(wettkampfTag);
@@ -85,7 +85,7 @@ public class SchuetzenstatistikComponentImplTest {
 
     public static SchuetzenstatistikDO getLigatabelleDO() {
         final SchuetzenstatistikDO expectedSchuetzenstatistikDO = new SchuetzenstatistikDO();
-        expectedSchuetzenstatistikDO.setveranstaltungId(veranstaltungId);
+        expectedSchuetzenstatistikDO.setveranstaltungId(VERANSTALTUNG_ID);
         expectedSchuetzenstatistikDO.setveranstaltungName(veranstaltungName);
         expectedSchuetzenstatistikDO.setwettkampfId(wettkampfId);
         expectedSchuetzenstatistikDO.setwettkampfTag(wettkampfTag);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistikLetzeJahre/api/types/SchuetzenstatistikLetzteJahreDOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistikLetzeJahre/api/types/SchuetzenstatistikLetzteJahreDOTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.*;
  * @author Alessa Hackh
  */
 public class SchuetzenstatistikLetzteJahreDOTest {
-    private static final String schuetzenname = "Name Schütze";
+    private static final String SCHUETZEN_NAME = "Name Schütze";
     private static final float sportjahr1 = (float) 8;
     private static final float sportjahr2 = (float) 7;
     private static final float sportjahr3 = (float) 6.5;
@@ -32,7 +32,7 @@ public class SchuetzenstatistikLetzteJahreDOTest {
     public static SchuetzenstatistikLetzteJahreDO getSchuetzenstatistikLetzteJahreDO() {
         final SchuetzenstatistikLetzteJahreDO expectedSchuetzenstatistikLetzteJahreDO = new SchuetzenstatistikLetzteJahreDO();
 
-        expectedSchuetzenstatistikLetzteJahreDO.setSchuetzenname(schuetzenname);
+        expectedSchuetzenstatistikLetzteJahreDO.setSchuetzenname(SCHUETZEN_NAME);
         expectedSchuetzenstatistikLetzteJahreDO.setSportjahr1(sportjahr1);
         expectedSchuetzenstatistikLetzteJahreDO.setSportjahr2(sportjahr2);
         expectedSchuetzenstatistikLetzteJahreDO.setSportjahr3(sportjahr3);


### PR DESCRIPTION
 [CleanCodeConvention](https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html)
"The names of variables declared class constants and of ANSI constants should be all uppercase with words separated by underscores ("_"). (ANSI constants should be avoided, for ease of debugging.)"


[Ticket #1845](https://gitlab.gras-it.de/hsrt/swt2/-/issues/1845)