### PR TITLE
#1702 Removed unused private field PRECONDITION_MSG_DSBMITGLIED_BEITRITTSDATUM

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmitglied/service/DsbMitgliedService.java
@@ -46,7 +46,6 @@ public class DsbMitgliedService implements ServiceFacade {
     private static final String PRECONDITION_MSG_DSBMITGLIED_VORNAME = "DsbMitglied vorname must not be null";
     private static final String PRECONDITION_MSG_DSBMITGLIED_NACHNAME = "DsbMitglied nachname must not be null";
     private static final String PRECONDITION_MSG_DSBMITGLIED_GEBURTSDATUM = "DsbMitglied geburtsdatum must not be null";
-    private static final String PRECONDITION_MSG_DSBMITGLIED_BEITRITTSDATUM = "DsbMitglied beitrittsdatum must not be null";
     private static final String PRECONDITION_MSG_DSBMITGLIED_NATIONALITAET = "DsbMitglied nationalitaet must not be null";
     private static final String PRECONDITION_MSG_DSBMITGLIED_MITGLIEDSNUMMER = "DsbMitglied mitgliedsnummer must not be null";
     private static final String PRECONDITION_MSG_DSBMITGLIED_VEREIN_ID = "DsbMitglied vereins id must not be null";


### PR DESCRIPTION
Ticket: https://gitlab.gras-it.de/hsrt/swt2/-/issues/1702 

Diese PR entfernt ein von SonarQube gemeldetes, nicht verwendetes privates Feld, toter Code.
(PRECONDITION_MSG_DSBMITGLIED_BEITRITTSDATUM) aus der Klasse DsbMitgliedService.java.