### PR TITLE
Ticket #1847 - Clean Code: Konstanten nach Java-Konvention in Großbuchstaben…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistikwettkampf/impl/dao/SchuetzenstatistikWettkampfDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistikwettkampf/impl/dao/SchuetzenstatistikWettkampfDAOTest.java
@@ -28,7 +28,7 @@ public class SchuetzenstatistikWettkampfDAOTest {
     private BasicDAO basicDao;
     @InjectMocks
     private SchuetzenstatistikWettkampfDAO underTest;
-    private static final Long wettkampfId = 2L;
+    private static final Long WETTKAMPF_ID = 2L;
     private static final Long vereinId = 7L;
     private static final Long veranstaltungId = 1L;
     private static final Long sportjahr = 0L;
@@ -72,7 +72,7 @@ public class SchuetzenstatistikWettkampfDAOTest {
         when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
 
         // call test method
-        final List<SchuetzenstatistikWettkampfBE> actual = underTest.getSchuetzenstatistikWettkampf(wettkampfId, vereinId);
+        final List<SchuetzenstatistikWettkampfBE> actual = underTest.getSchuetzenstatistikWettkampf(WETTKAMPF_ID, vereinId);
 
         // assert result
         assertThat(actual)

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/api/types/TriggerCountDOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/api/types/TriggerCountDOTest.java
@@ -8,10 +8,10 @@ import junit.framework.TestCase;
  * @author Andre Lehnert, eXXcellent solutions consulting & software gmbh
  */
 public class TriggerCountDOTest extends TestCase {
-    private static final Long count = 40000L;
+    private static final Long COUNT = 40000L;
     private static final Long altCount =50000L;
     public TriggerCountDO getExpectedCountDO() {
-        return new TriggerCountDO(count);
+        return new TriggerCountDO(COUNT);
     }
 
     @Test
@@ -19,7 +19,7 @@ public class TriggerCountDOTest extends TestCase {
         TriggerCountDO actualDO = getExpectedCountDO();
         Long actualCount = actualDO.getCount();
 
-        assertEquals(count, actualCount);
+        assertEquals(COUNT, actualCount);
     }
 
     @Test

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/api/types/TriggerDOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/api/types/TriggerDOTest.java
@@ -25,7 +25,7 @@ public class TriggerDOTest extends TestCase{
 
 
 	//Test data for setters
-	private static final Long newID = 8L;
+	private static final Long NEW_ID = 8L;
 	private static final String newKATEGORIE = "dumber";
 	private static final Long newALTSYSTEM_ID = 10L;
 	private static final TriggerChangeOperation newOPERATION = null;
@@ -50,10 +50,10 @@ public class TriggerDOTest extends TestCase{
 	@Test
 	public void testSetId(){
 		TriggerDO actual = getExpectedDTO();
-		actual.setId(newID);
+		actual.setId(NEW_ID);
 		Long actualId = actual.getId();
 
-		assertEquals(newID, actualId);
+		assertEquals(NEW_ID, actualId);
 	}
 
 	@Test

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerCountDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/dao/TriggerCountDAOTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
  * @author Andre Lehnert, eXXcellent solutions consulting & software gmbh
  */
 public class TriggerCountDAOTest{
-    private static final Long count = 40000L;
+    private static final Long COUNT = 40000L;
     private static final Long altCount =50000L;
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -30,7 +30,7 @@ public class TriggerCountDAOTest{
     private TriggerCountDAO triggerCountDAO;
     public static TriggerCountBE getTriggerCountBE() {
         TriggerCountBE countBE = new TriggerCountBE();
-        countBE.setCount(count);
+        countBE.setCount(COUNT);
         
         return countBE;
     }
@@ -41,7 +41,7 @@ public class TriggerCountDAOTest{
     public void testFindAllCount() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -57,7 +57,7 @@ public class TriggerCountDAOTest{
     public void testFindInProgressCount() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -73,7 +73,7 @@ public class TriggerCountDAOTest{
     public void testFindUnprocessedCount() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -88,7 +88,7 @@ public class TriggerCountDAOTest{
     public void testCountAllEntriesByStatusAndDateInterval() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -103,7 +103,7 @@ public class TriggerCountDAOTest{
     public void testCountSuccessedEntriesByStatusAndDateInterval() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -118,7 +118,7 @@ public class TriggerCountDAOTest{
     public void testCountInProgressEntriesByStatusAndDateInterval() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -133,7 +133,7 @@ public class TriggerCountDAOTest{
     public void testCountNewEntriesByStatusAndDateInterval() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);
@@ -148,7 +148,7 @@ public class TriggerCountDAOTest{
     public void testCountFailedEntriesByStatusAndDateInterval() {
         // prepare test data
         final TriggerCountBE expectedCountBE = getTriggerCountBE();
-        expectedCountBE.setCount(count);
+        expectedCountBE.setCount(COUNT);
 
         // configure mocks
         when(basicDAO.selectSingleEntity(any(), any(), any())).thenReturn(expectedCountBE);

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/entity/TriggerBETest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/entity/TriggerBETest.java
@@ -29,7 +29,7 @@ public class TriggerBETest {
 	private static final Long CHANGE_STATUS_ID = null;
 
 	//Test data for setters
-	private static final Long newCHANGE_OPERATION_ID = 123L;
+	private static final Long NEW_CHANGE_OPERATION_ID = 123L;
 	private static final Long newCHANGE_STATUS_ID = 123L;
 
 
@@ -77,10 +77,10 @@ public class TriggerBETest {
 	@Test
 	public void testSetChangeOperationId(){
 		TriggerBE actual = getTriggerBE();
-		actual.setChangeOperationId(newCHANGE_OPERATION_ID);
+		actual.setChangeOperationId(NEW_CHANGE_OPERATION_ID);
 		Long actualChangeOperationId = actual.getChangeOperationId();
 
-		assertEquals(newCHANGE_OPERATION_ID, actualChangeOperationId);
+		assertEquals(NEW_CHANGE_OPERATION_ID, actualChangeOperationId);
 	}
 	@Test
 	public void testGetChangeStatusID(){

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/entity/TriggerCountBETest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/entity/TriggerCountBETest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andre Lehnert, eXXcellent solutions consulting & software gmbh
  */
 public class TriggerCountBETest extends TestCase {
-    private static final Long count = 40000L;
+    private static final Long COUNT = 40000L;
     private static final Long altCount = 50000L;
     public TriggerCountBE getExpectedCountBE() {
         return new TriggerCountBE();
@@ -19,10 +19,10 @@ public class TriggerCountBETest extends TestCase {
     @Test
     public void testGetCount(){
         TriggerCountBE actualBE = getExpectedCountBE();
-        actualBE.setCount(count);
+        actualBE.setCount(COUNT);
         Long actualCount = actualBE.getCount();
 
-        assertEquals(count, actualCount);
+        assertEquals(COUNT, actualCount);
     }
 
     @Test
@@ -37,14 +37,14 @@ public class TriggerCountBETest extends TestCase {
     @Test
     public void testToString() {
         final TriggerCountBE actualBE = getExpectedCountBE();
-        actualBE.setCount(count);
+        actualBE.setCount(COUNT);
 
 
         final String actual = actualBE.toString();
 
         assertThat(actual)
                 .isNotEmpty()
-                .contains(Long.toString(count));
+                .contains(Long.toString(COUNT));
     }
 
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/mapper/TriggerMapperTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/trigger/impl/mapper/TriggerMapperTest.java
@@ -31,7 +31,7 @@ public class TriggerMapperTest {
 	private static final String NACHRICHT = "testmsg";
 	private static final Timestamp CREATED_AT_UTC = null;
 	private static final Timestamp RUN_AT_UTC = null;
-	private static final Long count = 40000L;
+	private static final Long COUNT = 40000L;
 	private static final Long altCount =50000L;
 
 
@@ -73,7 +73,7 @@ public class TriggerMapperTest {
 
 		final TriggerCountBE actual = TriggerMapper.toTriggerCountBE.apply(triggerCountDO);
 
-		assertThat(actual.getCount()).isEqualTo(count);
+		assertThat(actual.getCount()).isEqualTo(COUNT);
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class TriggerMapperTest {
 
 		final TriggerCountDO actual = TriggerMapper.toTriggerCountDO.apply(triggerCountBE);
 
-		assertThat(actual.getCount()).isEqualTo(count);
+		assertThat(actual.getCount()).isEqualTo(COUNT);
 	}
 
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
@@ -46,7 +46,7 @@ public class VereinComponentImplTest {
     private static final String REGION_KUERZEL = "tt";
     private static final String REGION_TYPE = "TE";
     private static final Long REGION_UEBERGEORDNET = 1L;
-    private static final String REGION_ÜBERGEORDNETASNAME ="Testübergeordnet";
+    private static final String REGION_UEBERGEORDNET_AS_NAME ="Testübergeordnet";
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -89,7 +89,7 @@ public class VereinComponentImplTest {
     //Test-Data for regionComponent
     public static RegionenDO getRegionenDO() {
         RegionenDO regionenDO = new RegionenDO(REGION_ID, REGION_NAME, REGION_KUERZEL,REGION_TYPE,
-                                            REGION_UEBERGEORDNET, REGION_ÜBERGEORDNETASNAME);
+                                            REGION_UEBERGEORDNET, REGION_UEBERGEORDNET_AS_NAME);
         return regionenDO;
     }
 

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.*;
  */
 public class WettkampfComponentImplTest {
 
-    private static final long user_Id = 13;
+    private static final long USER_ID = 13;
     private static final OffsetDateTime created_At_Utc = OffsetDateTime.now();
     private static final long version = 1234;
 
@@ -217,7 +217,7 @@ public class WettkampfComponentImplTest {
                 wettkampf_Disziplin_Id,
                 wettkampf_Wettkampftyp_Id,
                 created_At_Utc,
-                user_Id,
+                USER_ID,
                 version,
                 wettkampf_Ausrichter,
                 wettkampf_offlineToken
@@ -373,7 +373,7 @@ public class WettkampfComponentImplTest {
         when(wettkampfDAO.create(any(WettkampfBE.class), anyLong())).thenReturn(expectedBE);
 
         // call test method
-        final WettkampfDO actual = underTest.create(input, user_Id);
+        final WettkampfDO actual = underTest.create(input, USER_ID);
 
         // assert result
         assertThat(actual).isNotNull();
@@ -412,7 +412,7 @@ public class WettkampfComponentImplTest {
         when(wettkampfDAO.update(any(WettkampfBE.class), anyLong())).thenReturn(expectedBE);
 
         // call test method
-        final WettkampfDO actual = underTest.update(input, user_Id);
+        final WettkampfDO actual = underTest.update(input, USER_ID);
 
         // assert result
         assertThat(actual).isNotNull();
@@ -446,7 +446,7 @@ public class WettkampfComponentImplTest {
         final WettkampfBE expectedBE = getWettkampfBE();
 
         // call test method
-        underTest.delete(input, user_Id);
+        underTest.delete(input, USER_ID);
 
         // verify invocations
         verify(wettkampfDAO).delete(wettkampfBEArgumentCaptor.capture(), anyLong());
@@ -549,7 +549,7 @@ public class WettkampfComponentImplTest {
         when(wettkampfDAO.createWettkampftag0(anyLong(), anyLong())).thenReturn(expectedBE);
 
         // call test method
-        final WettkampfDO actual = underTest.createWT0(wettkampf_Veranstaltung_Id, user_Id);
+        final WettkampfDO actual = underTest.createWT0(wettkampf_Veranstaltung_Id, USER_ID);
 
         // assert result
         assertThat(actual).isNotNull();
@@ -787,9 +787,9 @@ public class WettkampfComponentImplTest {
 
     @Test
     public void generateOfflineToken() {
-            String token = underTest.generateOfflineToken(user_Id);
+            String token = underTest.generateOfflineToken(USER_ID);
             assertThat(token).isNotNull();
-            assertThat(token).contains(Long.toString(user_Id));
+            assertThat(token).contains(Long.toString(USER_ID));
     }
 
     @Test
@@ -820,7 +820,7 @@ public class WettkampfComponentImplTest {
 
         when(wettkampfDAO.update(any(),anyLong())).thenReturn(expected);
 
-        WettkampfDO actual = underTest.deleteOfflineToken(input, user_Id);
+        WettkampfDO actual = underTest.deleteOfflineToken(input, USER_ID);
 
         assertThat(actual.getId()).isEqualTo(expected.getId());
         assertThat(actual.getOfflineToken()).isNull();


### PR DESCRIPTION
… umbenannt, Umlaute ersetzt

Änderungen
- Umbenennung von Konstanten nach Namenskonvention
- Regex: ^[A-Z][A-Z0-9](_[A-Z0-9]+)$
- Änderungen vorgenommen in 9 Dateien

Beispiele
- wettkampfId → WETTKAMPF_ID
- count → COUNT