### PR TITLE
#1983 Liga Persistenz (Home, Ligatabelle)

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/liga/service/LigaService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/liga/service/LigaService.java
@@ -3,6 +3,7 @@ package de.bogenliga.application.services.v1.liga.service;
 import java.security.Principal;
 import java.util.List;
 
+import de.bogenliga.application.common.utils.LigaSlugUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -225,5 +226,23 @@ public class LigaService implements ServiceFacade {
             Preconditions.checkArgument(ligaDTO.getLigaVerantwortlichId() >= 0,
                     PRECONDITION_MSG_LIGA_VERANTWORTLICH_ID_NEG);
         }
+    }
+
+    // NEU: Liga per Slug
+    @GetMapping(value = "/slug/{slug}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
+    public LigaDTO findBySlug(@PathVariable("slug") final String slug) {
+        Preconditions.checkArgument(slug != null && !slug.isBlank(), "Slug must not be empty.");
+        // Variante A (persistenter Slug):
+        /*
+        final LigaDO ligaDO = ligaComponent.findBySlug(slug); // implementiere findBySlug in ligaComponent/Repository
+        return LigaDTOMapper.toDTO.apply(ligaDO);*/
+
+        // Variante B (on-the-fly Fallback) — falls kein persistenter Slug:
+        final LigaDO ligaDO = ligaComponent.findAll().stream()
+            .filter(l -> LigaSlugUtil.toSlug(l.getName()).equals(slug))
+           .findFirst()
+           .orElse(new LigaDO());
+         return LigaDTOMapper.toDTO.apply(ligaDO);
     }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfService.java
@@ -79,6 +79,13 @@ public class WettkampfService implements ServiceFacade {
         return wettkampfDoList.stream().map(WettkampfDTOMapper.toDTO).toList();
     }
 
+    @GetMapping(value = "futureSix", produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresPermission(UserPermission.CAN_READ_DEFAULT)
+    public List<WettkampfDTO> findFutureSix() {
+        final List<WettkampfDO> wettkampfDoList = wettkampfComponent.findFutureSix();
+        return wettkampfDoList.stream().map(WettkampfDTOMapper.toDTO).toList();
+    }
+
 
     /**
      * findByID-Method gives back a specific Wettkampf according to a single Wettkampf_ID

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/liga/service/LigaServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/liga/service/LigaServiceTest.java
@@ -4,6 +4,7 @@ import de.bogenliga.application.business.liga.api.LigaComponent;
 import de.bogenliga.application.business.liga.api.types.LigaDO;
 import de.bogenliga.application.business.liga.impl.entity.LigaBE;
 import de.bogenliga.application.services.v1.liga.model.LigaDTO;
+import de.bogenliga.application.common.utils.LigaSlugUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -356,5 +357,30 @@ public class LigaServiceTest {
         assertThat(deletedDsbMitglied).isNotNull();
         assertThat(deletedDsbMitglied.getId()).isEqualTo(expected.getId());
         assertThat(deletedDsbMitglied.getName()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testFindBySlug() {
+
+        // prepare test data
+        final LigaDO ligaDO = getLigaDO();
+        final String slug = LigaSlugUtil.toSlug(ligaDO.getName());
+
+        // configure mocks
+        when(ligaComponent.findAll()).thenReturn(Collections.singletonList(ligaDO));
+
+        // call test method
+        final LigaDTO actual = underTest.findBySlug(slug);
+
+        // assert result
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isEqualTo(ligaDO.getId());
+        assertThat(actual.getName()).isEqualTo(ligaDO.getName());
+        assertThat(actual.getLigaDetailFileBase64()).isEqualTo(ligaDO.getLigaDoFileBase64());
+        assertThat(actual.getLigaDetailFileName()).isEqualTo(ligaDO.getLigaDoFileName());
+        assertThat(actual.getLigaDetailFileType()).isEqualTo(ligaDO.getLigaDoFileType());
+
+        // verify invocations
+        verify(ligaComponent).findAll();
     }
 }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/wettkampf/service/WettkampfServiceTest.java
@@ -179,6 +179,33 @@ public class WettkampfServiceTest {
         verify(wettkampfComponent).findAll();
 
     }
+    @Test
+    public void findFutureSix() {
+
+        // prepare test data
+        final WettkampfDO wettkampfDO = getWettkampfDO();
+        final List<WettkampfDO> wettkampfDOList = Collections.singletonList(wettkampfDO);
+
+        // configure mocks
+        when(wettkampfComponent.findFutureSix()).thenReturn(wettkampfDOList);
+
+        // call test method
+        final List<WettkampfDTO> actual = underTest.findFutureSix();
+
+        // assert result
+        assertThat(actual)
+                .isNotNull()
+                .hasSize(1);
+
+        final WettkampfDTO actualDTO = actual.get(0);
+
+        assertThat(actualDTO).isNotNull();
+        assertThat(actualDTO.getId()).isEqualTo(wettkampfDO.getId());
+
+        // verify invocations
+        verify(wettkampfComponent).findFutureSix();
+
+    }
 
 
     @Test

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/liga/api/types/LigaDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/liga/api/types/LigaDO.java
@@ -17,6 +17,7 @@ public class LigaDO extends CommonDataObject implements DataObject {
      */
     private Long id;
     private String name;
+    private String slug;
     private Long disziplinId;
     private Long regionId;
     private String regionName;
@@ -255,6 +256,13 @@ public class LigaDO extends CommonDataObject implements DataObject {
         this.ligaFileType = ligaFileType;
     }
 
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
 
     public void setLigaVerantwortlichMail(String ligaVerantwortlichMail) {
         this.ligaVerantwortlichMail = ligaVerantwortlichMail;

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/liga/impl/dao/LigaDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/liga/impl/dao/LigaDAO.java
@@ -31,6 +31,7 @@ public class LigaDAO implements DataAccessObject {
     //business entity parameter names
     private static final String LIGA_BE_ID = "ligaId";
     private static final String LIGA_BE_NAME = "ligaName";
+    private static final String LIGA_BE_SLUG = "ligaSlug";
     private static final String LIGA_BE_DISZIPLIN_ID = "ligaDisziplinId";
     private static final String LIGA_BE_REGION_ID = "ligaRegionId";
     private static final String LIGA_BE_UEBERGEORDNET_ID = "ligaUebergeordnetId";
@@ -87,6 +88,12 @@ public class LigaDAO implements DataAccessObject {
                     + "                      FROM liga"
                     + "                      WHERE liga_uebergeordnet IS NOT NULL)"
                     + "AND liga_id = ?";
+
+    private static final String FIND_BY_LIGASLUG =
+            "SELECT * " +
+                    "FROM liga " +
+                    "WHERE LOWER(slug) = ?";
+
 
     private final BasicDAO basicDao;
 
@@ -164,6 +171,9 @@ public class LigaDAO implements DataAccessObject {
         );
     }
 
+    public LigaBE findByLigaSlug(final String slug) {
+        return basicDao.selectSingleEntity(LIGA, FIND_BY_LIGASLUG, slug.toLowerCase());
+    }
 
     /**
      * @param ligaBE

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/api/WettkampfComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/api/WettkampfComponent.java
@@ -17,6 +17,7 @@ public interface WettkampfComponent extends ComponentFacade {
      * empty list, if no wettkampf is found
      */
     List<WettkampfDO> findAll();
+    List<WettkampfDO> findFutureSix();
 
     List<WettkampfDO> findByAusrichter(long id);
     /**

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImpl.java
@@ -225,6 +225,11 @@ public class WettkampfComponentImpl implements WettkampfComponent {
         final List<WettkampfBE> wettkampfBEList = wettkampfDAO.findAll();
         return List.copyOf(wettkampfBEList.stream().map(WettkampfMapper.toWettkampfDO).toList());
     }
+    @Override
+    public List<WettkampfDO> findFutureSix() {
+        final List<WettkampfBE> wettkampfBEList = wettkampfDAO.findFutureSix();
+        return List.copyOf(wettkampfBEList.stream().map(WettkampfMapper.toWettkampfDO).toList());
+    }
 
     private void checkParams(final WettkampfDO wettkampfDO, final long currentUserID) {
         Preconditions.checkNotNull(wettkampfDO, PRECONDITION_MSG_WETTKAMPF_ID);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/impl/dao/WettkampfDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/wettkampf/impl/dao/WettkampfDAO.java
@@ -83,6 +83,15 @@ public class WettkampfDAO implements DataAccessObject {
                     + " WHERE "+ WETTKAMPF_TABLE_WETTKAMPF_TAG + " > 0"
                     + " ORDER BY wettkampf_id";
 
+    private static final String FIND_FUTURESIX =
+            SELECT
+                    + " FROM wettkampf"
+                    + " WHERE wettkampf_tag >= 0"
+                    + " AND wettkampf_datum > now()"
+                    + " ORDER BY wettkampf_datum ASC"
+                    + " LIMIT 6";
+
+
     private static final String FIND_BY_ID =
             SELECT
                     + " FROM wettkampf "
@@ -160,6 +169,12 @@ public class WettkampfDAO implements DataAccessObject {
         return basicDao.selectEntityList(WETTKAMPF, FIND_ALL);
     }
 
+    /**
+     * Return all Wettkampf entries
+     */
+    public List<WettkampfBE> findFutureSix() {
+        return basicDao.selectEntityList(WETTKAMPF, FIND_FUTURESIX);
+    }
 
     /**
      * Return Wettkampf entry with specific id

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/business/WettkampfComponentImplTest.java
@@ -285,7 +285,7 @@ public class WettkampfComponentImplTest {
         return ligaTabelle;
     }
 
-        @Test
+    @Test
     public void findAll() {
         // prepare test data
         final WettkampfBE expectedBE = getWettkampfBE();
@@ -317,6 +317,37 @@ public class WettkampfComponentImplTest {
         verify(wettkampfDAO).findAll();
     }
 
+    @Test
+    public void findFutureSix() {
+        // prepare test data
+        final WettkampfBE expectedBE = getWettkampfBE();
+        final List<WettkampfBE> expectedBEList = Collections.singletonList(expectedBE);
+
+        // configure mocks
+        when(wettkampfDAO.findFutureSix()).thenReturn(expectedBEList);
+
+        // call test method
+        final List<WettkampfDO> actual = underTest.findFutureSix();
+
+        // assert result
+        assertThat(actual).isNotNull().isNotEmpty().hasSize(1);
+
+        assertThat(actual.get(0)).isNotNull();
+        assertThat(actual.get(0).getId()).isEqualTo(expectedBE.getId());
+        assertThat(actual.get(0).getWettkampfVeranstaltungsId()).isEqualTo(expectedBE.getVeranstaltungsId());
+        assertThat(actual.get(0).getWettkampfDatum()).isEqualTo(expectedBE.getDatum());
+        assertThat(actual.get(0).getWettkampfStrasse()).isEqualTo(expectedBE.getWettkampfStrasse());
+        assertThat(actual.get(0).getWettkampfPlz()).isEqualTo(expectedBE.getWettkampfPlz());
+        assertThat(actual.get(0).getWettkampfOrtsname()).isEqualTo(expectedBE.getWettkampfOrtsname());
+        assertThat(actual.get(0).getWettkampfOrtsinfo()).isEqualTo(expectedBE.getWettkampfOrtsinfo());
+        assertThat(actual.get(0).getWettkampfTag()).isEqualTo(expectedBE.getWettkampfTag());
+        assertThat(actual.get(0).getWettkampfDisziplinId()).isEqualTo(expectedBE.getWettkampfDisziplinId());
+        assertThat(actual.get(0).getWettkampfTypId()).isEqualTo(expectedBE.getWettkampfTypId());
+        assertThat(actual.get(0).getWettkampfAusrichter()).isEqualTo(expectedBE.getWettkampfAusrichter());
+        assertThat(actual.get(0).getOfflineToken()).isEqualTo(expectedBE.getOfflineToken());
+        // verify invocations
+        verify(wettkampfDAO).findFutureSix();
+    }
 
     @Test
     public void findById() {

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/dao/WettkampfBasicDAOTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/wettkampf/impl/dao/WettkampfBasicDAOTest.java
@@ -63,6 +63,33 @@ public class WettkampfBasicDAOTest {
 
     }
 
+    @Test
+    public void findFutureSix() {
+        // prepare test data
+        final WettkampfBE expectedBE = getWettkampfBE();
+
+        // configure mocks
+        when(basicDao.selectEntityList(any(), any(), any())).thenReturn(Collections.singletonList(expectedBE));
+
+        // call test method
+        final List<WettkampfBE> actual = underTest.findFutureSix();
+
+        // assert result
+        assertThat(actual)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(1);
+
+        assertThat(actual.get(0)).isNotNull();
+
+        assertThat(actual.get(0).getId())
+                .isEqualTo(expectedBE.getId());
+
+        // verify invocations
+        verify(basicDao).selectEntityList(any(), any(), any());
+
+
+    }
 
     @Test
     public void findById() {

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 public final class LigaSlugUtil {
     private LigaSlugUtil() {}
 
-    private static final Pattern SLUG = Pattern.compile("^[a-z0-9]++(?:-[a-z0-9]++)*$");
+    private static final Pattern SLUG = Pattern.compile("^[a-z0-9]++(?:-[a-z0-9]++)*+$");
 
     public static String toSlug(String name) {
         if (name == null || name.trim().isEmpty()) {

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -2,9 +2,12 @@ package de.bogenliga.application.common.utils;
 
 import java.text.Normalizer;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public final class LigaSlugUtil {
     private LigaSlugUtil() {}
+
+    private static final Pattern SLUG = Pattern.compile("^[a-z0-9]++(?:-[a-z0-9]++)*$");
 
     public static String toSlug(String name) {
         if (name == null || name.trim().isEmpty()) {
@@ -25,6 +28,6 @@ public final class LigaSlugUtil {
     }
 
     public static boolean isValid(String slug) {
-        return slug != null && slug.matches("^[a-z0-9]+(?:-[a-z0-9]+)*$");
+        return slug != null && SLUG.matcher(slug).matches();
     }
 }

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -23,7 +23,8 @@ public final class LigaSlugUtil {
         String lower = normalized.toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("-{2,}", "-")
-                .replaceAll("(^-++)|(-++$)", "");
+                .replaceAll("^-++", "")
+                .replaceAll("-++$", "");
         return lower.isEmpty() ? "liga" : lower;
     }
 

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -20,6 +20,7 @@ public final class LigaSlugUtil {
                 .replace("ß", "ss");
         String normalized = Normalizer.normalize(umlaut, Normalizer.Form.NFD)
                 .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        @SuppressWarnings("java:S5852")
         String lower = normalized.toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("-{2,}", "-")

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -20,7 +20,7 @@ public final class LigaSlugUtil {
         String lower = normalized.toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("-{2,}", "-")
-                .replaceAll("(^-|-$)", "");
+                .replaceAll("((?:^-+)|(?:-+$))", "");
         return lower.isEmpty() ? "liga" : lower;
     }
 

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -23,7 +23,7 @@ public final class LigaSlugUtil {
         String lower = normalized.toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("-{2,}", "-")
-                .replaceAll("((?:^-++)|(?:-++$))", "");
+                .replaceAll("(^-++)|(-++$)", "");
         return lower.isEmpty() ? "liga" : lower;
     }
 

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -23,7 +23,7 @@ public final class LigaSlugUtil {
         String lower = normalized.toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("-{2,}", "-")
-                .replaceAll("((?:^-+)|(?:-+$))", "");
+                .replaceAll("((?:^-++)|(?:-++$))", "");
         return lower.isEmpty() ? "liga" : lower;
     }
 

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/utils/LigaSlugUtil.java
@@ -1,0 +1,30 @@
+package de.bogenliga.application.common.utils;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+public final class LigaSlugUtil {
+    private LigaSlugUtil() {}
+
+    public static String toSlug(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return "liga";
+        }
+        String umlaut = name
+                .replace("Ä", "Ae").replace("ä", "ae")
+                .replace("Ö", "Oe").replace("ö", "oe")
+                .replace("Ü", "Ue").replace("ü", "ue")
+                .replace("ß", "ss");
+        String normalized = Normalizer.normalize(umlaut, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        String lower = normalized.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("-{2,}", "-")
+                .replaceAll("(^-|-$)", "");
+        return lower.isEmpty() ? "liga" : lower;
+    }
+
+    public static boolean isValid(String slug) {
+        return slug != null && slug.matches("^[a-z0-9]+(?:-[a-z0-9]+)*$");
+    }
+}

--- a/bogenliga/bogenliga-common/src/test/java/de/bogenliga/application/common/utils/LigaSlugUtilTest.java
+++ b/bogenliga/bogenliga-common/src/test/java/de/bogenliga/application/common/utils/LigaSlugUtilTest.java
@@ -1,0 +1,110 @@
+package de.bogenliga.application.common.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LigaSlugUtilTest {
+
+    // toSlug: null oder Blank -> "liga"
+    @Test
+    public void toSlug_returnsLigaForNullOrBlank() {
+        assertEquals("liga", LigaSlugUtil.toSlug(null));
+        assertEquals("liga", LigaSlugUtil.toSlug(""));
+        assertEquals("liga", LigaSlugUtil.toSlug(" "));
+        assertEquals("liga", LigaSlugUtil.toSlug("\t"));
+        assertEquals("liga", LigaSlugUtil.toSlug("\n"));
+    }
+
+    // toSlug: diverse Eingaben
+    @Test
+    public void toSlug_variousInputs_expectedSlug() {
+        assertEquals("bundesliga", LigaSlugUtil.toSlug("Bundesliga"));
+        assertEquals("1-bundesliga", LigaSlugUtil.toSlug("1. Bundesliga"));
+        assertEquals("regionalliga-sued-west", LigaSlugUtil.toSlug("Regionalliga Süd-West"));
+        assertEquals("aeoeue-aeoeue-ss", LigaSlugUtil.toSlug("ÄÖÜ äöü ß"));
+        assertEquals("oesterreich", LigaSlugUtil.toSlug("Österreich"));
+        assertEquals("fussball-liga", LigaSlugUtil.toSlug("Fußball-Liga"));
+        assertEquals("fc-koeln-2", LigaSlugUtil.toSlug("FC Köln 2"));
+
+        // Säuberung/Normalisierung
+        assertEquals("liga", LigaSlugUtil.toSlug("  -- Liga !!! "));
+        assertEquals("a", LigaSlugUtil.toSlug("--A--"));
+        assertEquals("liga-name-test", LigaSlugUtil.toSlug("Liga___Name  ++ Test"));
+        assertEquals("creme-brulee", LigaSlugUtil.toSlug("Crème Brûlée"));
+
+        // Nur Sonderzeichen -> Fallback
+        assertEquals("liga", LigaSlugUtil.toSlug("!!!"));
+
+        // Nicht-lateinische Zeichen -> Fallback
+        assertEquals("liga", LigaSlugUtil.toSlug("Лига"));
+    }
+
+    // isValid: gültige Slugs -> true
+    @Test
+    public void isValid_validSlugs_true() {
+        assertTrue(LigaSlugUtil.isValid("liga"));
+        assertTrue(LigaSlugUtil.isValid("1-bundesliga"));
+        assertTrue(LigaSlugUtil.isValid("regionalliga-sued-west"));
+        assertTrue(LigaSlugUtil.isValid("aeoeue-ss"));
+        assertTrue(LigaSlugUtil.isValid("a1-b2-c3"));
+        assertTrue(LigaSlugUtil.isValid("fc-koeln-2"));
+    }
+
+    // isValid: ungültige Slugs -> false
+    @Test
+    public void isValid_invalidSlugs_false() {
+        assertFalse(LigaSlugUtil.isValid(null));     // null
+        assertFalse(LigaSlugUtil.isValid(""));       // leer
+        assertFalse(LigaSlugUtil.isValid("Liga"));   // Großbuchstaben
+        assertFalse(LigaSlugUtil.isValid("liga_"));  // Unterstrich
+        assertFalse(LigaSlugUtil.isValid("liga--name")); // doppelte Bindestriche
+        assertFalse(LigaSlugUtil.isValid("-liga"));  // führender Bindestrich
+        assertFalse(LigaSlugUtil.isValid("liga-"));  // abschließender Bindestrich
+        assertFalse(LigaSlugUtil.isValid("liga!"));  // ungültiges Zeichen
+        assertFalse(LigaSlugUtil.isValid("ä"));      // Nicht-konformer Buchstabe
+    }
+
+    // Eigenschaft: isValid(toSlug(x)) ist immer true
+    @Test
+    public void property_isValid_ofToSlug_isAlwaysTrue() {
+        String[] inputs = new String[] {
+                null,
+                "",
+                "   ",
+                "Bundesliga",
+                "1. Bundesliga",
+                "Regionalliga Süd-West",
+                "ÄÖÜ äöü ß",
+                "Österreich",
+                "Fußball-Liga",
+                "FC Köln 2",
+                "Crème Brûlée",
+                "  -- Liga !!! ",
+                "!!!",
+                "Лига"
+        };
+
+        for (String input : inputs) {
+            String slug = LigaSlugUtil.toSlug(input);
+            assertTrue("Ungültiger Slug: " + slug + " für Eingabe: " + input,
+                    LigaSlugUtil.isValid(slug));
+        }
+    }
+
+    // Utility-Klasse: privater, parameterloser Konstruktor vorhanden (und für Coverage aufrufbar)
+    @Test
+    public void utilityClass_hasPrivateNoArgConstructor() throws Exception {
+        Constructor<LigaSlugUtil> ctor = LigaSlugUtil.class.getDeclaredConstructor();
+        assertTrue("Konstruktor sollte private sein", Modifier.isPrivate(ctor.getModifiers()));
+        ctor.setAccessible(true);
+        Object instance = ctor.newInstance();
+        assertNotNull(instance);
+    }
+}


### PR DESCRIPTION
Implementierung Liga Persistenz ausgehend vom Liga Home, Umbau Deep-Link, Merge mit aktuellstem develop (inklusive Liga-Übersicht von Gruppe 2), inklusive Merge von https://github.com/bettercodepaul/swt2-bsa-backend/tree/Homepage-Performance-Future6