### PR TITLE
Release 1.1 bugfix swt2#1977

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
@@ -122,7 +122,6 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
 
             List<MannschaftsmitgliedDO> mannschaftsmitgliedList = new ArrayList<>();
 
-            int count = 0;
             for (MannschaftsmitgliedDO mannschaftsmitglied : mannschaftsmitgliedDOList) {
                 DsbMitgliedDO dsbMitglied = dsbMitgliedComponent.findById(mannschaftsmitglied.getDsbMitgliedId());
                 long thisLiga = this.veranstaltungComponent.findById(this.wettkampfComponent.findById(
@@ -201,7 +200,6 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                 // allowedMapping.put(dsbMitglied, darfSchiessen);
                 allowedMapping.put(mannschaftsmitglied, true);
 
-                count++;
             }
             teamMemberMapping.put(teamName, mannschaftsmitgliedList);
 
@@ -358,9 +356,7 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                 ;
 
                 //Add content to player columns
-                if (allowedMapping.get(teamMemberMapping.get(
-                        teamNameList[manschaftCounter]).get(
-                        mitgliedCounter - 1))) {
+                if (allowedMapping.get(teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1))) {
                     tableBodyFirstPart
                             .addCell(new Cell().setBorder(Border.NO_BORDER)
                                     .add(tableCheckbox1.setBorder(Border.NO_BORDER)))

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
@@ -196,15 +196,11 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                 }
                 // Füge mitglieder mit schusserlaubnis hinzu
                 dsbMitgliedDOList.add(dsbMitglied);
-                allowedMapping.put(dsbMitglied, darfSchiessen);
-                if (darfSchiessen) {
-                    LOGGER.info("Teammitglied {} {} wurde gefunden", dsbMitgliedDOList.get(count).getNachname(),
-                            dsbMitgliedDOList.get(count).getVorname());
-                } else {
-                    LOGGER.info(
-                            "Teammitglied {} {} konnte nicht hinzugefügt werden, da es schon in einer höheren Liga oder am selben Wettkampftag geschossen hat.",
-                            dsbMitglied.getNachname(), dsbMitglied.getVorname());
-                }
+                //TODO Bugfix für die Prüfung auf Schusserlaubnis
+                //aktueller Workaround: alle dürfen....
+                // allowedMapping.put(dsbMitglied, darfSchiessen);
+                allowedMapping.put(dsbMitglied, true);
+
                 count++;
             }
             teamMemberMapping.put(teamName, dsbMitgliedDOList);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
@@ -102,8 +102,8 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
         Preconditions.checkArgument(wettkampfid >= 0, PRECONDITION_WETTKAMPFID);
 
         // Initialisierung Dsb Mitglied Hashmap und DsbMitglied, boolean Hashmap.
-        HashMap<String, List<DsbMitgliedDO>> teamMemberMapping = new HashMap<>();
-        HashMap<DsbMitgliedDO, Boolean> allowedMapping = new HashMap<>();
+        HashMap<String, List<MannschaftsmitgliedDO>> teamMemberMapping = new HashMap<>();
+        HashMap<MannschaftsmitgliedDO, Boolean>  allowedMapping = new HashMap<>();
 
         // Informationen sammeln Wettkampf und zugehoerige Veranstaltung
         WettkampfDO wettkampfDO = wettkampfComponent.findById(wettkampfid);
@@ -120,7 +120,7 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
             List<MannschaftsmitgliedDO> mannschaftsmitgliedDOList = mannschaftsmitgliedComponent.findAllSchuetzeInTeam(
                     matchDO.getMannschaftId());
 
-            List<DsbMitgliedDO> dsbMitgliedDOList = new ArrayList<>();
+            List<MannschaftsmitgliedDO> mannschaftsmitgliedList = new ArrayList<>();
 
             int count = 0;
             for (MannschaftsmitgliedDO mannschaftsmitglied : mannschaftsmitgliedDOList) {
@@ -195,15 +195,15 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                     }
                 }
                 // Füge mitglieder mit schusserlaubnis hinzu
-                dsbMitgliedDOList.add(dsbMitglied);
+                mannschaftsmitgliedList.add(mannschaftsmitglied);
                 //TODO Bugfix für die Prüfung auf Schusserlaubnis
                 //aktueller Workaround: alle dürfen....
                 // allowedMapping.put(dsbMitglied, darfSchiessen);
-                allowedMapping.put(dsbMitglied, true);
+                allowedMapping.put(mannschaftsmitglied, true);
 
                 count++;
             }
-            teamMemberMapping.put(teamName, dsbMitgliedDOList);
+            teamMemberMapping.put(teamName, mannschaftsmitgliedList);
 
 
         }
@@ -245,9 +245,9 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
      * @param teamMemberMapping Key: TeamName String, Value: List of DSBMitgliedDO (Contains shooters)
      */
     private void generateBogenkontrolllisteDoc(Document doc, WettkampfDO wettkampfDO,
-                                               HashMap<String, List<DsbMitgliedDO>> teamMemberMapping,
+                                               HashMap<String, List<MannschaftsmitgliedDO>> teamMemberMapping,
                                                String veranstaltungsName,
-                                               HashMap<DsbMitgliedDO, Boolean> allowedMapping, int veranstaltungGroesse) {
+                                               HashMap<MannschaftsmitgliedDO, Boolean> allowedMapping, int veranstaltungGroesse) {
         Preconditions.checkNotNull(doc, PRECONDITION_DOCUMENT);
         Preconditions.checkNotNull(wettkampfDO, PRECONDITION_WETTKAMPFDO);
         Preconditions.checkArgument(!teamMemberMapping.isEmpty(), PRECONDITION_TEAM_MAPPING);
@@ -361,29 +361,21 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                 if (allowedMapping.get(teamMemberMapping.get(
                         teamNameList[manschaftCounter]).get(
                         mitgliedCounter - 1))) {
-
                     tableBodyFirstPart
                             .addCell(new Cell().setBorder(Border.NO_BORDER)
                                     .add(tableCheckbox1.setBorder(Border.NO_BORDER)))
                             .addCell(new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.LEFT)
-                                    .add(new Paragraph(mitgliedCounter + " " + teamMemberMapping.get(
-                                            teamNameList[manschaftCounter]).get(
-                                            mitgliedCounter - 1).getNachname() + ", " + teamMemberMapping.get(
-                                            teamNameList[manschaftCounter]).get(
-                                            mitgliedCounter - 1).getVorname()).setBold().setFontSize(10.0F)))
-                    ;
+                                    .add(new Paragraph(teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getRueckennummer() + " " +
+                                            teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getDsbMitgliedNachname() + ", " +
+                                            teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getDsbMitgliedVorname()).setBold().setFontSize(10.0F)));
                 } else {
                     tableBodyFirstPart
                             .addCell(new Cell().setBorder(Border.NO_BORDER)
                                     .add(tableCheckbox1.setBorder(Border.NO_BORDER)))
                             .addCell(new Cell().setBorder(Border.NO_BORDER).setTextAlignment(TextAlignment.LEFT)
-                                    .add(new Paragraph(mitgliedCounter + " " + teamMemberMapping.get(
-                                            teamNameList[manschaftCounter]).get(
-                                            mitgliedCounter - 1).getNachname() + ", " + teamMemberMapping.get(
-                                            teamNameList[manschaftCounter]).get(
-                                            mitgliedCounter - 1).getVorname()).setBold().setLineThrough().setFontSize(
-                                            10.0F)))
-                    ;
+                                    .add(new Paragraph(teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getRueckennummer() + " " +
+                                            teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getDsbMitgliedNachname() + ", " +
+                                            teamMemberMapping.get(teamNameList[manschaftCounter]).get(mitgliedCounter - 1).getDsbMitgliedVorname()).setBold().setLineThrough().setFontSize(10.0F)));
                 }
 
                 for (int match = 0; match < numberOfMatches; match++) {

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
@@ -100,6 +100,7 @@ public class MannschaftsmitgliedDO extends CommonDataObject implements DataObjec
         this.dsbMitgliedVorname = dsbMitgliedVorname;
         this.dsbMitgliedNachname = dsbMitgliedNachname;
         this.rueckennummer = rueckennummer;
+        this.version = -1L;
 
     }
 
@@ -199,14 +200,12 @@ public class MannschaftsmitgliedDO extends CommonDataObject implements DataObjec
             return false;
         }
         final MannschaftsmitgliedDO that = (MannschaftsmitgliedDO) o;
-        return lastModifiedByUserId.equals(that.lastModifiedByUserId) &&
-                version.equals(that.version) &&
+        return version.equals(that.version) &&
                 mannschaftId.equals(that.mannschaftId) &&
                 dsbMitgliedId.equals(that.dsbMitgliedId) &&
                 dsbMitgliedEingesetzt.equals(that.dsbMitgliedEingesetzt) &&
                 dsbMitgliedVorname.equals(that.dsbMitgliedVorname) &&
                 dsbMitgliedNachname.equals(that.dsbMitgliedNachname) &&
-                lastModifiedAtUtc.equals(that.lastModifiedAtUtc) &&
                 rueckennummer.equals(that.rueckennummer);
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
@@ -112,7 +112,7 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
                     DSB_MITGLIED_TABLE_MITGLIED_ID)
             .whereGteRaw(MANNSCHAFTSMITGLIED_TABLE_EMPLOYED, "1")
             .andEquals(MANNSCHAFTSMITGLIED_TABLE_TEAM_ID)
-            .orderBy(MANNSCHAFTSMITGLIED_TABLE_ID)
+            .orderBy(MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER)
             .compose().toString();
 
     //hier suchen wir  alle Teammtiglieder, die potentiell eingesetzt werden könnten
@@ -124,7 +124,7 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
             .on(TABLE_ALIAS, MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID, DSB_MITGLIED_TABLE_ALIAS,
                     DSB_MITGLIED_TABLE_MITGLIED_ID)
             .whereEquals(MANNSCHAFTSMITGLIED_TABLE_TEAM_ID)
-            .orderBy(MANNSCHAFTSMITGLIED_TABLE_ID)
+            .orderBy(MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER)
             .compose().toString();
 
 


### PR DESCRIPTION
https://gitlab.gras-it.de/hsrt/swt2/-/issues/1977
Korrektur zur Verwendung der korrekten Rueckenummern und der Reihnefolge der Mannschaftmitglieder entsprechend der Rueckenummern in Bogenkontrollliste und Meldezetteln