### PR TITLE
Enabled database schema selection

### DIFF
--- a/bogenliga/bogenliga-application/src/main/resources/application-LOCAL.properties
+++ b/bogenliga/bogenliga-application/src/main/resources/application-LOCAL.properties
@@ -4,6 +4,8 @@ database.port=5432
 database.databaseName=swt2
 database.user=swt2
 database.password=swt2
+#database.schema=public
+#flyway.migration.skip=true
 
 # JSON Web Token - Security properties
 ## UNSECURE!!!

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/configuration/DatabaseConfiguration.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/configuration/DatabaseConfiguration.java
@@ -16,6 +16,7 @@ public class DatabaseConfiguration {
     private String databaseName;
     private String user;
     private String password;
+    private String schema= "public";
 
 
     /**
@@ -115,5 +116,22 @@ public class DatabaseConfiguration {
      */
     public void setPassword(final String password) {
         this.password = password;
+    }
+
+    /**
+     * Setter
+     *
+     * @return schema
+     */
+    public String getSchema() {
+        return schema;
+    }
+
+    /**
+     * Setter
+     *
+     * @param schema
+     */    public void setSchema(final String schema) {
+        this.schema = schema;
     }
 }

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/database/migration/DatabaseMigration.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/database/migration/DatabaseMigration.java
@@ -41,6 +41,8 @@ public class DatabaseMigration{
     @Value("${spring.flyway.locations}")
     private String[] locations;
 
+    @Value("${flyway.migration.skip:false}")
+    private boolean skipFlyWayMigration;
 
     /**
      * I will be automatically called at spring startup to start the database migration.
@@ -49,6 +51,12 @@ public class DatabaseMigration{
      */
     @PostConstruct
     public void startDBMigration(){
+
+        if(skipFlyWayMigration) {
+            LOG.info("Skipping Database Migration as flyway.migration is disabled.");
+            return;
+        }
+
         LOG.info("Starting Database Migration: ");
         try {
             //Set Logger for Output while Migation is running.

--- a/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/database/tx/PostgresqlTransactionManager.java
+++ b/bogenliga/bogenliga-common/src/main/java/de/bogenliga/application/common/database/tx/PostgresqlTransactionManager.java
@@ -153,15 +153,17 @@ public class PostgresqlTransactionManager implements TransactionManager {
     public DataSource getDataSource() {
         if (ds == null) {
             try {
-                LOG.debug("Database connection: jdbc:postgresql://{}:{}/{} with user '{}' and password length '{}'",
+                LOG.debug("Database connection: jdbc:postgresql://{}:{}/{} with user '{}' and password length '{}' and schema '{}'",
                         databaseConfiguration.getHost(), databaseConfiguration.getPort(),
                         databaseConfiguration.getDatabaseName(), databaseConfiguration.getUser(),
-                        databaseConfiguration.getPassword().length());
+                        databaseConfiguration.getPassword().length(), databaseConfiguration.getSchema());
 
                 PGSimpleDataSource postgresqlDatasource = new PGSimpleDataSource();  // Empty instance.
                 // The value `localhost` means the Postgres cluster running locally on the same machine.
                 postgresqlDatasource.setServerName(databaseConfiguration.getHost());
                 postgresqlDatasource.setPortNumber(databaseConfiguration.getPort());
+
+                postgresqlDatasource.setCurrentSchema(databaseConfiguration.getSchema());
                 // A connection to Postgres must be made to a specific database rather than to the server as a whole.
                 // You likely have an initial database created named `public`.
                 postgresqlDatasource.setDatabaseName(databaseConfiguration.getDatabaseName());


### PR DESCRIPTION
Die neuen Felder können in den application properties verwendet werden:
#database.schema= e.g. publicprod
#flyway.migration.skip=true 

Für das wechseln zwischen schemas. Die flyway migration muss deaktiviert werden da sonst die daten im gewählten schema überschrieben werden.

Code Coverage sind nur getter und setter zu vernachlässigen