### PR TITLE
fehlendes Selektieren der technischen Parameter in Mannschaftsmiglied…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/bogenkontrollliste/impl/business/BogenkontrolllisteComponentImpl.java
@@ -157,6 +157,9 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                         dsbMitglied.getId());
 
                 // Finde alle Wettkämpfe einer Mannschaft
+                //aktueller Workaround: alle dürfen....
+                //TODO Bugfix für die Prüfung auf Schusserlaubnis
+                /*
                 for (MannschaftsmitgliedDO mitglied : mitgliedIn) {
                     List<WettkampfDO> wettkaempfe = this.wettkampfComponent.findAllWettkaempfeByMannschaftsId(
                             mitglied.getMannschaftId());
@@ -193,6 +196,8 @@ public class BogenkontrolllisteComponentImpl implements BogenkontrolllisteCompon
                         }
                     }
                 }
+
+                 */
                 // Füge mitglieder mit schusserlaubnis hinzu
                 mannschaftsmitgliedList.add(mannschaftsmitglied);
                 //TODO Bugfix für die Prüfung auf Schusserlaubnis

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
@@ -199,17 +199,13 @@ public class MannschaftsmitgliedDO extends CommonDataObject implements DataObjec
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (this.version == null) {
-            //Fallback for uninitialized "selected ext-BE " without technical fields
-            this.version = 0L;
-        }
         final MannschaftsmitgliedDO that = (MannschaftsmitgliedDO) o;
         return Objects.equals(version, that.version) &&
-                mannschaftId.equals(that.mannschaftId) &&
-                dsbMitgliedId.equals(that.dsbMitgliedId) &&
-                dsbMitgliedEingesetzt.equals(that.dsbMitgliedEingesetzt) &&
-                dsbMitgliedVorname.equals(that.dsbMitgliedVorname) &&
-                dsbMitgliedNachname.equals(that.dsbMitgliedNachname) &&
-                rueckennummer.equals(that.rueckennummer);
+                Objects.equals(mannschaftId, that.mannschaftId) &&
+                Objects.equals(dsbMitgliedId, that.dsbMitgliedId) &&
+                Objects.equals(dsbMitgliedEingesetzt, that.dsbMitgliedEingesetzt) &&
+                Objects.equals(dsbMitgliedVorname, that.dsbMitgliedVorname) &&
+                Objects.equals(dsbMitgliedNachname, that.dsbMitgliedNachname) &&
+                Objects.equals(rueckennummer, that.rueckennummer);
     }
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
@@ -199,6 +199,10 @@ public class MannschaftsmitgliedDO extends CommonDataObject implements DataObjec
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (this.version == null) {
+            //Fallback for uninitialized "selected ext-BE " without technical fields
+            this.version = 0L;
+        }
         final MannschaftsmitgliedDO that = (MannschaftsmitgliedDO) o;
         return version.equals(that.version) &&
                 mannschaftId.equals(that.mannschaftId) &&

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/api/types/MannschaftsmitgliedDO.java
@@ -204,7 +204,7 @@ public class MannschaftsmitgliedDO extends CommonDataObject implements DataObjec
             this.version = 0L;
         }
         final MannschaftsmitgliedDO that = (MannschaftsmitgliedDO) o;
-        return version.equals(that.version) &&
+        return Objects.equals(version, that.version) &&
                 mannschaftId.equals(that.mannschaftId) &&
                 dsbMitgliedId.equals(that.dsbMitgliedId) &&
                 dsbMitgliedEingesetzt.equals(that.dsbMitgliedEingesetzt) &&

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/mannschaftsmitglied/impl/dao/MannschaftsmitgliedDAO.java
@@ -48,6 +48,13 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
     private static final String MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID = "mannschaftsmitglied_dsb_mitglied_id";
     private static final String MANNSCHAFTSMITGLIED_TABLE_EMPLOYED = "mannschaftsmitglied_dsb_mitglied_eingesetzt";
 
+    private static final String MANNSCHAFTMITGLIED_TABLE_VERSION = "m.version";
+    private static final String MANNSCHAFTMITGLIED_TABLE_CREATED_AT = "m.created_at_utc";
+    private static final String MANNSCHAFTSMITGLIED_TABLE_CREATED_BY = "m.created_by";
+    private static final String MANNSCHAFTSMITGLIED_TABLE_LAST_MODIFIED_AT = "m.last_modified_at_utc";
+    private static final String MANNSCHAFTSMITGLIED_TABLE_LAST_MODIFIED_BY = "m.last_modified_by";
+
+
     // new: important for the join with dsb_mitglied
     private static final String DSBMITGLIED_TABLE_FORENAME = "dsb_mitglied_vorname";
     private static final String DSBMITGLIED_TABLE_SURNAME = "dsb_mitglied_nachname";
@@ -55,7 +62,9 @@ public class MannschaftsmitgliedDAO implements DataAccessObject {
 
     private static final String[] selectedFields = {
             MANNSCHAFTSMITGLIED_TABLE_ID, MANNSCHAFTSMITGLIED_TABLE_TEAM_ID, MANNSCHAFTSMITGLIED_TABLE_DSB_MITGLIED_ID,
-            MANNSCHAFTSMITGLIED_TABLE_EMPLOYED, DSBMITGLIED_TABLE_FORENAME, DSBMITGLIED_TABLE_SURNAME, MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER
+            MANNSCHAFTSMITGLIED_TABLE_EMPLOYED, DSBMITGLIED_TABLE_FORENAME, DSBMITGLIED_TABLE_SURNAME, MANNSCHAFTSMITGLIED_TABLE_RUECKENNUMMER,
+            MANNSCHAFTMITGLIED_TABLE_VERSION, MANNSCHAFTMITGLIED_TABLE_CREATED_AT, MANNSCHAFTSMITGLIED_TABLE_CREATED_BY,
+            MANNSCHAFTSMITGLIED_TABLE_LAST_MODIFIED_AT, MANNSCHAFTSMITGLIED_TABLE_LAST_MODIFIED_BY
     };
 
     private static final String FIND_ALL = new QueryBuilder()


### PR DESCRIPTION
…DAO ergänzt und Null-Pointer Exception in "equals" des Datentypen abgefangen

Weiter die Prüfung auf "schon mal geschossen" komplett auskommentiert, damit auch keine Laufzeit übrig bleibt...