### PR TITLE
style: rename schuetzeSatz1 to match Java constant naming conventions

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/impl/business/SchuetzenstatistikComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schuetzenstatistik/impl/business/SchuetzenstatistikComponentImplTest.java
@@ -40,7 +40,7 @@ public class SchuetzenstatistikComponentImplTest {
     private static final String dsbMitgliedName = "Mitglied_Name";
     private static final int rueckenNummer = 5;
     private static final float pfeilpunkteSchnitt = (float) 3.7;
-    private static final String schuetzeSatz1 = "10,5,6,null,9,9";
+    private static final String SCHUETZE_SATZ_1 = "10,5,6,null,9,9";
     private static final String schuetzeSatz2 = "4,10,null,null,7,8";
     private static final String schuetzeSatz3 = "10,null,8,null,9,null";
     private static final String schuetzeSatz4 = "null,3,8,null,10,3";
@@ -74,7 +74,7 @@ public class SchuetzenstatistikComponentImplTest {
         expectedSchuetzenstatistikBE.setDsbMitgliedName(dsbMitgliedName);
         expectedSchuetzenstatistikBE.setRueckenNummer(rueckenNummer);
         expectedSchuetzenstatistikBE.setPfeilpunkteSchnitt(pfeilpunkteSchnitt);
-        expectedSchuetzenstatistikBE.setschuetzeSatz1(schuetzeSatz1);
+        expectedSchuetzenstatistikBE.setschuetzeSatz1(SCHUETZE_SATZ_1);
         expectedSchuetzenstatistikBE.setschuetzeSatz2(schuetzeSatz2);
         expectedSchuetzenstatistikBE.setschuetzeSatz3(schuetzeSatz3);
         expectedSchuetzenstatistikBE.setschuetzeSatz4(schuetzeSatz4);


### PR DESCRIPTION
Changes

- Renamed `schuetzeSatz1` to align with Java's standard constant naming conventions.