### PR TITLE
Remove redundant NoPermissionException from SyncService signature

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -227,7 +227,7 @@ public class SyncService implements ServiceFacade {
     @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_WETTKAMPF})
     public List<WettkampfExtDTO> getToken(
             @PathVariable("id") final long wettkampfId,
-            final Principal principal) throws NoPermissionException {
+            final Principal principal) {
         Preconditions.checkArgument(wettkampfId >= 0, PRECONDITION_MSG_WETTKAMPF_ID);
         logger.debug("Received 'update' request with id '{}' to add offline token", wettkampfId);
         // Check if it is the ligaleiter of the wettkampfs liga (not sure if possible); generic check done in permissions

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/sync/service/SyncService.java
@@ -68,6 +68,8 @@ public class SyncService implements ServiceFacade {
     private static final String CHECKED_PARAM_MATCH_ID = "Match ID";
     private static final String ERR_NOT_NEGATIVE_TEMPLATE = "MatchService: %s: %s must not be negative.";
     private static final String ERR_WETTKAMPF_ALREADY_OFFLINE = "Cannot got offline. Wettkampf is already offline";
+    private static final String ERR_SYNC_MITGLIEDER_PERMISSION = "error syncing mitglieder";
+    private static final String ERR_SYNC_MATCHES_PERMISSION = "error syncing matches and passen";
 
 
     private static final String PRECONDITION_MSG_OFFLINE_TOKEN = "Offlinetoken must not be null";
@@ -272,7 +274,7 @@ public class SyncService implements ServiceFacade {
     public ResponseEntity checkOfflineTokenAndSynchronizeMannschaftsMitglieder(@PathVariable("id") final long wettkampfId,
                                                                                @RequestBody final List<LigaSyncMannschaftsmitgliedDTO> mannschaftsMitgliedDTOList,
                                                                                final Principal principal
-    ) throws NoPermissionException {
+    ) {
 
         Preconditions.checkArgument(wettkampfId >= 0, PRECONDITION_MSG_WETTKAMPF_ID);
 
@@ -284,8 +286,12 @@ public class SyncService implements ServiceFacade {
         for(LigaSyncMannschaftsmitgliedDTO ligaSyncMannschaftsmitgliedDTO: mannschaftsMitgliedDTOList){
 
             MannschaftsMitgliedDTO newMannschaftsMitgliedDTO = LigaSyncMannschaftsmitgliedDTOMapper.toMannschaftsmitgliedDTO.apply(ligaSyncMannschaftsmitgliedDTO);
-
-            MannschaftsMitgliedDTO addedNewMannschaftsMitgliedDO = mannschaftsMitgliedService.create(newMannschaftsMitgliedDTO, principal);
+            final MannschaftsMitgliedDTO addedNewMannschaftsMitgliedDO;
+            try {
+                addedNewMannschaftsMitgliedDO = mannschaftsMitgliedService.create(newMannschaftsMitgliedDTO, principal);
+            } catch (NoPermissionException e) {
+                throw new BusinessException(ErrorCode.NO_PERMISSION_ERROR, ERR_SYNC_MITGLIEDER_PERMISSION, e);
+            }
 
 
             savedMannschaftsMitglieder.add( MannschaftsMitgliedDTOMapper.toDO.apply(addedNewMannschaftsMitgliedDO));
@@ -309,7 +315,7 @@ public class SyncService implements ServiceFacade {
     @RequiresPermission(UserPermission.CAN_MODIFY_WETTKAMPF)
     public List<MatchDTO> synchronizeMatchesAndPassen(List<LigaSyncMatchDTO> ligaSyncMatchDTOs,
                                                       List<LigaSyncPasseDTO> ligaSyncPasseDTOs,
-                                                      Principal principal) throws NoPermissionException {
+                                                      Principal principal) {
 
         List<MatchDTO> matchDTOs = new ArrayList<>();
 
@@ -362,7 +368,11 @@ public class SyncService implements ServiceFacade {
                     twoMatchesDTO.add(matchDTOs.get(j));
                     logger.debug("second match found: match 1 {} match 2 {} ", twoMatchesDTO.get(0).getId(), twoMatchesDTO.get(1).getId());
                     logger.debug("second match found: matchnr 1 {} matchnr 2 {} ", twoMatchesDTO.get(0).getPassen().get(0).getMatchNr(), twoMatchesDTO.get(1).getPassen().get(0).getMatchNr());
-                    matchService.saveMatches(twoMatchesDTO, principal);
+                    try {
+                        matchService.saveMatches(twoMatchesDTO, principal);
+                    } catch (NoPermissionException e) {
+                        throw new BusinessException(ErrorCode.NO_PERMISSION_ERROR, ERR_SYNC_MATCHES_PERMISSION, e);
+                    }
                     logger.debug("save matches");
                 }
             }
@@ -423,20 +433,12 @@ public class SyncService implements ServiceFacade {
 
         // handle mannschaftsmitglieder
         final List<LigaSyncMannschaftsmitgliedDTO> mannschaftsmitgliedDTOS = syncPayload.getMannschaftsmitglied();
-        try {
-            checkOfflineTokenAndSynchronizeMannschaftsMitglieder(wettkampfId, mannschaftsmitgliedDTOS, principal);
-        } catch (NoPermissionException e) {
-            throw new BusinessException(ErrorCode.UNDEFINED, "error syncing mitglieder");
-        }
+        checkOfflineTokenAndSynchronizeMannschaftsMitglieder(wettkampfId, mannschaftsmitgliedDTOS, principal);
         // handle matches
-        List<MatchDTO> response;
+        final List<MatchDTO> response;
         final List<LigaSyncMatchDTO> matchDTOS = syncPayload.getMatch();
         final List<LigaSyncPasseDTO> passeDTOS = syncPayload.getPasse();
-        try {
-            response = synchronizeMatchesAndPassen(matchDTOS, passeDTOS, principal);
-        } catch (NoPermissionException e) {
-            throw new BusinessException(ErrorCode.UNDEFINED, "error syncing matches and passen");
-        }
+        response = synchronizeMatchesAndPassen(matchDTOS, passeDTOS, principal);
         // delete offline token
         WettkampfDO wettkampfDO = wettkampfComponent.findById(wettkampfId);
         wettkampfComponent.deleteOfflineToken(wettkampfDO, userId);

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/Sync/service/SyncServiceTest.java
@@ -1285,26 +1285,22 @@ public class SyncServiceTest {
         when(wettkampfComponent.findById(anyLong())).thenReturn(getDO);
         when(wettkampfComponent.update(any(), anyLong())).thenReturn(expected);
 
-        try {
-            // call test method
-            final List<WettkampfExtDTO> actual = underTest.getToken(id, principal);
+        // call test method
+        final List<WettkampfExtDTO> actual = underTest.getToken(id, principal);
 
-            // assert result
-            assertThat(actual).isNotNull();
-            assertThat(actual.get(0).getId()).isEqualTo(input.getId());
-            assertThat(actual.get(0).getOfflineToken()).isNotNull();
-            assertThat(actual.get(0).getOfflineToken()).isEqualTo(result.getOfflineToken());
+        // assert result
+        assertThat(actual).isNotNull();
+        assertThat(actual.get(0).getId()).isEqualTo(input.getId());
+        assertThat(actual.get(0).getOfflineToken()).isNotNull();
+        assertThat(actual.get(0).getOfflineToken()).isEqualTo(result.getOfflineToken());
 
-            // verify invocations
-            verify(wettkampfComponent).update(wettkampfDOArgumentCaptor.capture(), anyLong());
+        // verify invocations
+        verify(wettkampfComponent).update(wettkampfDOArgumentCaptor.capture(), anyLong());
 
-            final WettkampfDO updatedWettkampf = wettkampfDOArgumentCaptor.getValue();
+        final WettkampfDO updatedWettkampf = wettkampfDOArgumentCaptor.getValue();
 
-            assertThat(updatedWettkampf).isNotNull();
-            assertThat(updatedWettkampf.getId()).isEqualTo(input.getId());
-
-        } catch (NoPermissionException e) {
-        }
+        assertThat(updatedWettkampf).isNotNull();
+        assertThat(updatedWettkampf.getId()).isEqualTo(input.getId());
     }
 
 
@@ -1396,20 +1392,15 @@ public class SyncServiceTest {
         //when(wettkampfComponent.deleteOfflineToken();)
 
 
-        try {
-            List<MatchDTO> actual = underTest.synchronizeMatchesAndPassen(ligaSyncMatchDTOs, ligaSyncPasseDTOs, principal);
-            assertThat(actual).isNotNull().isNotEmpty().hasSize(4);
+        List<MatchDTO> actual = underTest.synchronizeMatchesAndPassen(ligaSyncMatchDTOs, ligaSyncPasseDTOs, principal);
+        assertThat(actual).isNotNull().isNotEmpty().hasSize(4);
 
-            for (int i = 0; i < expectedMatchDTOs.size(); i++) {
+        for (int i = 0; i < expectedMatchDTOs.size(); i++) {
 
-                assertThat(actual.get(i).getPassen()).isNotNull().isNotEmpty().hasSize(1);
-                assertThat(actual.get(i).getId()).isEqualTo(expectedMatchDTOs.get(i).getId());
-                assertThat(actual.get(i).getPassen().get(0).getMatchId()).isEqualTo(expectedMatchDTOs.get(i).getPassen().get(0).getMatchId());
-                assertThat(actual.get(i).getMatchNr()).isEqualTo(expectedMatchDTOs.get(i).getMatchNr());
-            }
-
-        } catch (NoPermissionException e) {
-
+            assertThat(actual.get(i).getPassen()).isNotNull().isNotEmpty().hasSize(1);
+            assertThat(actual.get(i).getId()).isEqualTo(expectedMatchDTOs.get(i).getId());
+            assertThat(actual.get(i).getPassen().get(0).getMatchId()).isEqualTo(expectedMatchDTOs.get(i).getPassen().get(0).getMatchId());
+            assertThat(actual.get(i).getMatchNr()).isEqualTo(expectedMatchDTOs.get(i).getMatchNr());
         }
     }
 


### PR DESCRIPTION
Removed the unnecessary NoPermissionException from the method signature, since it is not thrown within the method body.