### PR TITLE
#1700 Replace Stream.collect with Stream.toList

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/schusszettel/mapper/TabletSatzEingabeMapper.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/schusszettel/mapper/TabletSatzEingabeMapper.java
@@ -22,7 +22,7 @@ public class TabletSatzEingabeMapper {
         doObj.setSatzeingabe(
                 dto.getSatzeingabe().stream()
                         .map(TabletSatzEingabeMapper::toDO)
-                        .collect(Collectors.toList())
+                        .toList()
         );
         return doObj;
     }
@@ -32,7 +32,7 @@ public class TabletSatzEingabeMapper {
         dto.setSatzeingabe(
                 doObj.getSatzeingabe().stream()
                         .map(TabletSatzEingabeMapper::toDTO)
-                        .collect(Collectors.toList())
+                        .toList()
         );
         return dto;
     }


### PR DESCRIPTION
Replaced usages of collect(Collectors.toList()) with Stream.toList() in TabletSatzEingabeMapper.

The change affects mapper logic used in TabletSchusszettelService for processing SatzEingabe (score input).

Tested:
- Backend runs
- Frontend runs
- Application loads without errors