### PR TITLE
Fix user overview to include users without roles

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -64,6 +64,11 @@ public class DsbMannschaftService implements ServiceFacade {
     private final DsbMannschaftComponent dsbMannschaftComponent;
     private final VeranstaltungComponent veranstaltungComponent;
     private final RequiresOnePermissionAspect requiresOnePermissionAspect;
+
+    private static final String ERROR_MSG_CREATE_MANNSCHAFT_NO_PERMISSION = "Keine Berechtigung zum Erstellen einer Mannschaft";
+    private static final String ERROR_MSG_PLATZHALTER_NO_PERMISSION = "Sie haben keine Berechtigung für diese Aktion.";
+    private static final String ERROR_MSG_DELETE_MANNSCHAFT_NO_PERMISSION = "Löschen einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
+
     MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
 
     /**
@@ -273,7 +278,7 @@ public class DsbMannschaftService implements ServiceFacade {
      */
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresOnePermissions(perm = {UserPermission.CAN_CREATE_MANNSCHAFT,UserPermission.CAN_MODIFY_MY_VEREIN})
-    public DsbMannschaftDTO create(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal) throws NoPermissionException {
+    public DsbMannschaftDTO create(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal){
         //Check if the User has a General Permission or,
         //check if his vereinId equals the vereinId of the mannschaft he wants to create a Team in
         //and if the user has the permission to modify his verein.
@@ -329,7 +334,12 @@ public class DsbMannschaftService implements ServiceFacade {
 
             return DsbMannschaftDTOMapper.toDTO.apply(savedDsbMannschaftDO);
 
-        } else throw new NoPermissionException();
+        } else {
+            throw new BusinessException(
+                    ErrorCode.NO_PERMISSION_ERROR,
+                    ERROR_MSG_CREATE_MANNSCHAFT_NO_PERMISSION
+            );
+        }
     }
 
 
@@ -360,7 +370,7 @@ public class DsbMannschaftService implements ServiceFacade {
                                     final List<DsbMannschaftDO> allExistingPlatzhalterList,
                                     final DsbMannschaftDTO dsbMannschaftDTO,
                                     final int veranstaltungsgroesse,
-                                    final Principal principal) throws NoPermissionException {
+                                    final Principal principal) {
 
         // Check if the user has the required permission
         if (this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_CREATE_MANNSCHAFT) ||
@@ -400,7 +410,10 @@ public class DsbMannschaftService implements ServiceFacade {
             }
         } else {
             // Throw an exception if the user does not have permission
-            throw new NoPermissionException();
+            throw new BusinessException(
+                    ErrorCode.NO_PERMISSION_ERROR,
+                    ERROR_MSG_PLATZHALTER_NO_PERMISSION
+            );
         }
     }
 
@@ -579,7 +592,7 @@ public class DsbMannschaftService implements ServiceFacade {
      */
     @DeleteMapping(value = "{id}")
     @RequiresOnePermissions(perm = {UserPermission.CAN_DELETE_STAMMDATEN, UserPermission.CAN_MODIFY_MY_VERANSTALTUNG})
-    public void delete(@PathVariable("id") final long id, final Principal principal) throws NoPermissionException {
+    public void delete(@PathVariable("id") final long id, final Principal principal) {
         Preconditions.checkArgument(id >= 0, PRECONDITION_MSG_ID_NEGATIVE);
         // allow value == null, the value will be ignored
         final DsbMannschaftDO dsbMannschaftDO = dsbMannschaftComponent.findById(id);
@@ -589,7 +602,10 @@ public class DsbMannschaftService implements ServiceFacade {
 
         if(!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_DELETE_STAMMDATEN)
                 && !this.requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(UserPermission.CAN_MODIFY_MY_VERANSTALTUNG, dsbMannschaftComponent.findById(id).getVeranstaltungId())){
-            throw new NoPermissionException();
+            throw new BusinessException(
+                    ErrorCode.NO_PERMISSION_ERROR,
+                    ERROR_MSG_DELETE_MANNSCHAFT_NO_PERMISSION
+            );
         }
 
         // Wenn eine Veranstaltung zugeordnet ist (id!=null) und die Phase ist nicht "Geplant", dann nicht löschen

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -68,6 +68,7 @@ public class DsbMannschaftService implements ServiceFacade {
     private static final String ERROR_MSG_CREATE_MANNSCHAFT_NO_PERMISSION = "Keine Berechtigung zum Erstellen einer Mannschaft";
     private static final String ERROR_MSG_PLATZHALTER_NO_PERMISSION = "Sie haben keine Berechtigung für diese Aktion.";
     private static final String ERROR_MSG_DELETE_MANNSCHAFT_NO_PERMISSION = "Löschen einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
+    private static final String ERROR_MSG_UPDATE_MANNSCHAFT_NO_PERMISSION = "Ändern einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
 
     MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
 
@@ -541,7 +542,7 @@ public class DsbMannschaftService implements ServiceFacade {
      */
     @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresOnePermissions( perm = {UserPermission.CAN_MODIFY_MANNSCHAFT, UserPermission.CAN_MODIFY_MY_VEREIN})
-    public DsbMannschaftDTO update(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal) throws NoPermissionException {
+    public DsbMannschaftDTO update(@RequestBody final DsbMannschaftDTO dsbMannschaftDTO, final Principal principal) {
         //Check if the User has a General Permission or,
         //check if his vereinId equals the vereinId of the mannschaft he wants to modify a Team in
         //and if the user has the permission to modify his verein.
@@ -549,7 +550,10 @@ public class DsbMannschaftService implements ServiceFacade {
         DsbMannschaftDO dsbMannschaftDO = this.dsbMannschaftComponent.findById(dsbMannschaftDTO.getId());
         if(!this.requiresOnePermissionAspect.hasPermission(UserPermission.CAN_MODIFY_MANNSCHAFT) && (!this.requiresOnePermissionAspect.hasSpecificPermissionSportleiter(UserPermission.CAN_MODIFY_MY_VEREIN, dsbMannschaftDTO.getVereinId())
                     ||!dsbMannschaftDO.getVeranstaltungId().equals(dsbMannschaftDTO.getVeranstaltungId()))) {
-                throw new NoPermissionException();
+                throw new BusinessException(
+                        ErrorCode.NO_PERMISSION_ERROR,
+                        ERROR_MSG_UPDATE_MANNSCHAFT_NO_PERMISSION
+                );
         }
 
         checkPreconditions(dsbMannschaftDTO);

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -408,7 +408,7 @@ public class DsbMannschaftServiceTest {
             assertThat(createdDsbMannschaft.getSortierung()).isEqualTo(input.getSortierung());
             assertThat(createdDsbMannschaft.getSportjahr()).isEqualTo(input.getSportjahr());
 
-        } catch (NoPermissionException e) { }
+        } catch (BusinessException e) { }
     }
 
     @Test
@@ -452,7 +452,7 @@ public class DsbMannschaftServiceTest {
             assertThat(createdDsbMannschaft.getSortierung()).isEqualTo(platzhalterDTO.getSortierung());
             assertThat(createdDsbMannschaft.getSportjahr()).isEqualTo(platzhalterDTO.getSportjahr());
 
-        } catch (NoPermissionException e) { }
+        } catch (BusinessException e) { }
     }
 
 
@@ -516,7 +516,7 @@ public class DsbMannschaftServiceTest {
             underTest.checkForPlatzhalter(actualMannschaftInVeranstaltungCount,
                     allExistingPlatzhalterList, platzhalterDTO, veranstaltunggroesse, principal);
 
-        }catch (NoPermissionException ignored) {}
+        }catch (BusinessException ignored) {}
     }
 
     @Test
@@ -557,7 +557,7 @@ public class DsbMannschaftServiceTest {
 
             assertThat(deletedDsbMannschaft).isNotNull();
 
-        }catch (NoPermissionException ignored) {}
+        }catch (BusinessException ignored) {}
     }
 
 
@@ -663,7 +663,7 @@ public class DsbMannschaftServiceTest {
         assertThat(deletedDsbMannschaft).isNotNull();
         assertThat(deletedDsbMannschaft.getId()).isEqualTo(expected.getId());
         assertThat(deletedDsbMannschaft.getVereinId()).isEqualTo(VEREIN_ID);
-        }catch (NoPermissionException e) { }
+        }catch (BusinessException e) { }
     }
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -596,7 +596,7 @@ public class DsbMannschaftServiceTest {
             assertThat(updatedDsbMannschaft.getSortierung()).isEqualTo(input.getSortierung());
             assertThat(updatedDsbMannschaft.getSportjahr()).isEqualTo(input.getSportjahr());
 
-        } catch (NoPermissionException e) { }
+        } catch (BusinessException e) { }
     }
 
 

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -467,7 +467,7 @@ public class DsbMannschaftServiceTest {
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
 
-        assertThatExceptionOfType(NoPermissionException.class)
+        assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(()-> underTest.create(input, principal));
     }
 
@@ -611,7 +611,7 @@ public class DsbMannschaftServiceTest {
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(false);
         when(requiresOnePermissionAspect.hasSpecificPermissionSportleiter(any(), anyLong())).thenReturn(false);
 
-        assertThatExceptionOfType(NoPermissionException.class)
+        assertThatExceptionOfType(BusinessException.class)
                 .isThrownBy(()-> underTest.update(input, principal));
     }
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImpl.java
@@ -13,6 +13,7 @@ import de.bogenliga.application.business.mannschaftsmitglied.api.types.Mannschaf
 import de.bogenliga.application.business.namemapping.api.NameMappingComponent;
 import de.bogenliga.application.common.errorhandling.ErrorCode;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
+import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
 import de.bogenliga.application.common.validation.Preconditions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,8 @@ public class DsbMannschaftComponentImpl implements DsbMannschaftComponent, DsbMa
     private static final String PRECONDITION_MSG_SORTIERUNG = "The Sortierung must not be null or negative";
     private static final String PRECONDITION_MSG_VERANSTALTUNGS_ID = "Veranstaltungs ID must not be negative";
     private static final String PRECONDITION_MSG_WETTKAMPF_ID = "Wettkampf ID must not be negative";
+    private static final String DUPLICATE_MANNSCHAFT_CONSTRAINT = "cu_mannschaft_veranstaltung";
+    private static final String EXCEPTION_DUPLICATE_MANNSCHAFT = "Duplicate Mannschaft for verein/nummer/veranstaltung";
 
     private static final String EXCEPTION_NO_RESULTS = "No result for ID '%s'";
 
@@ -162,7 +165,15 @@ public class DsbMannschaftComponentImpl implements DsbMannschaftComponent, DsbMa
         checkDsbMannschaftDO(dsbMannschaftDO, currentUserId);
 
         final DsbMannschaftBE dsbMannschaftBE = DsbMannschaftMapper.toDsbMannschaftBE.apply(dsbMannschaftDO);
-        final DsbMannschaftBE persistedDsbMannschaftBE = dsbMannschaftDAO.create(dsbMannschaftBE, currentUserId);
+        final DsbMannschaftBE persistedDsbMannschaftBE;
+        try {
+            persistedDsbMannschaftBE = dsbMannschaftDAO.create(dsbMannschaftBE, currentUserId);
+        } catch (TechnicalException e) {
+            if (isDuplicateMannschaftConflict(e)) {
+                throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, EXCEPTION_DUPLICATE_MANNSCHAFT);
+            }
+            throw e;
+        }
 
         return fillName(DsbMannschaftMapper.toDsbMannschaftDO.apply(persistedDsbMannschaftBE));
     }
@@ -176,9 +187,23 @@ public class DsbMannschaftComponentImpl implements DsbMannschaftComponent, DsbMa
         checkSortierung(dsbMannschaftDO); //To avoid corruption of the Sortierung
 
         final DsbMannschaftBE dsbMannschaftBE = DsbMannschaftMapper.toDsbMannschaftBE.apply(dsbMannschaftDO);
-        final DsbMannschaftBE persistedDsbMannschaftBE = dsbMannschaftDAO.update(dsbMannschaftBE, currentUserId);
+        final DsbMannschaftBE persistedDsbMannschaftBE;
+        try {
+            persistedDsbMannschaftBE = dsbMannschaftDAO.update(dsbMannschaftBE, currentUserId);
+        } catch (TechnicalException e) {
+            if (isDuplicateMannschaftConflict(e)) {
+                throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, EXCEPTION_DUPLICATE_MANNSCHAFT);
+            }
+            throw e;
+        }
 
         return fillName(DsbMannschaftMapper.toDsbMannschaftDO.apply(persistedDsbMannschaftBE));
+    }
+
+    private boolean isDuplicateMannschaftConflict(final TechnicalException e) {
+        return e.getErrorCode() == ErrorCode.DATABASE_ERROR
+                && e.getMessage() != null
+                && e.getMessage().contains(DUPLICATE_MANNSCHAFT_CONSTRAINT);
     }
 
     // Löschen von Mannschaften

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/dao/UserRoleExtDAO.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/user/impl/dao/UserRoleExtDAO.java
@@ -54,13 +54,13 @@ public class UserRoleExtDAO extends UserRoleDAO implements DataAccessObject {
      * SQL queries
      */
     private static final String FIND_ALL =
-            "SELECT benutzer_rolle.benutzer_rolle_benutzer_id, benutzer.benutzer_email, benutzer.benutzer_active, "
+            "SELECT benutzer.benutzer_id AS benutzer_rolle_benutzer_id, benutzer.benutzer_email, benutzer.benutzer_active, "
                     + " benutzer_rolle.benutzer_rolle_rolle_id, rolle.rolle_name, dsb_mitglied.dsb_mitglied_nachname, dsb_mitglied.dsb_mitglied_vorname "
-                    + " FROM benutzer_rolle, benutzer, rolle, dsb_mitglied"
-                    + " WHERE benutzer_rolle.benutzer_rolle_benutzer_id = benutzer.benutzer_id "
-                    + " AND benutzer_rolle.benutzer_rolle_rolle_id = rolle.rolle_id "
-                    + " AND benutzer.benutzer_dsb_mitglied_id = dsb_mitglied.dsb_mitglied_id"
-                    + " AND benutzer.benutzer_active = TRUE";
+                    + " FROM benutzer "
+                    + " LEFT JOIN benutzer_rolle ON benutzer.benutzer_id = benutzer_rolle.benutzer_rolle_benutzer_id "
+                    + " LEFT JOIN rolle ON benutzer_rolle.benutzer_rolle_rolle_id = rolle.rolle_id "
+                    + " LEFT JOIN dsb_mitglied ON benutzer.benutzer_dsb_mitglied_id = dsb_mitglied.dsb_mitglied_id "
+                    + " WHERE benutzer.benutzer_active = TRUE";
 
     private static final String FIND_BY_SEARCH =
             "SELECT benutzer_rolle.benutzer_rolle_benutzer_id, benutzer.benutzer_email, benutzer.benutzer_active, "

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -14,6 +14,7 @@ import de.bogenliga.application.business.vereine.api.VereinComponent;
 import de.bogenliga.application.business.vereine.api.types.VereinDO;
 import de.bogenliga.application.common.errorhandling.ErrorCode;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
+import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -634,6 +635,19 @@ public class DsbMannschaftComponentImplTest {
         verifyZeroInteractions(vereinComponent);
     }
 
+        @Test
+        public void create_duplicateMannschaftConstraint_shouldThrowConflict() {
+                final DsbMannschaftDO input = getDsbMannschaftDO();
+
+                when(dsbMannschaftDAO.create(any(DsbMannschaftBE.class), anyLong()))
+                                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                                                "duplicate key value violates unique constraint \"cu_mannschaft_veranstaltung\""));
+
+                assertThatThrownBy(() -> underTest.create(input, USER))
+                                .isInstanceOf(BusinessException.class)
+                                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+        }
+
 
     @Test
     public void update() {
@@ -703,6 +717,21 @@ public class DsbMannschaftComponentImplTest {
         verifyZeroInteractions(dsbMannschaftDAO);
         verifyZeroInteractions(vereinComponent);
     }
+
+        @Test
+        public void update_duplicateMannschaftConstraint_shouldThrowConflict() {
+                final DsbMannschaftDO input = getDsbMannschaftDO();
+                final DsbMannschaftBE existingBE = getDsbMannschaftBE();
+
+                when(dsbMannschaftDAO.findById(anyLong())).thenReturn(existingBE);
+                when(dsbMannschaftDAO.update(any(DsbMannschaftBE.class), anyLong()))
+                                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                                                "duplicate key value violates unique constraint \"cu_mannschaft_veranstaltung\""));
+
+                assertThatThrownBy(() -> underTest.update(input, USER))
+                                .isInstanceOf(BusinessException.class)
+                                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+        }
 
     @Test
     public void update_checkSortierung() {

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/dsbmannschaft/impl/business/DsbMannschaftComponentImplTest.java
@@ -648,6 +648,40 @@ public class DsbMannschaftComponentImplTest {
                                 .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
         }
 
+        @Test
+        public void create_nonDatabaseTechnicalException_shouldRethrowOriginalException() {
+                final DsbMannschaftDO input = getDsbMannschaftDO();
+                final TechnicalException expectedException =
+                                new TechnicalException(ErrorCode.INTERNAL_ERROR, "unexpected technical failure");
+
+                when(dsbMannschaftDAO.create(any(DsbMannschaftBE.class), anyLong()))
+                                .thenThrow(expectedException);
+
+                try {
+                        underTest.create(input, USER);
+                        Assertions.fail("Expected TechnicalException to be thrown");
+                } catch (TechnicalException actualException) {
+                        assertThat(actualException).isSameAs(expectedException);
+                }
+        }
+
+        @Test
+        public void create_databaseErrorWithoutDuplicateConstraint_shouldRethrowTechnicalException() {
+                final DsbMannschaftDO input = getDsbMannschaftDO();
+                final TechnicalException expectedException =
+                                new TechnicalException(ErrorCode.DATABASE_ERROR, "some other database error");
+
+                when(dsbMannschaftDAO.create(any(DsbMannschaftBE.class), anyLong()))
+                                .thenThrow(expectedException);
+
+                try {
+                        underTest.create(input, USER);
+                        Assertions.fail("Expected TechnicalException to be thrown");
+                } catch (TechnicalException actualException) {
+                        assertThat(actualException).isSameAs(expectedException);
+                }
+        }
+
 
     @Test
     public void update() {
@@ -731,6 +765,31 @@ public class DsbMannschaftComponentImplTest {
                 assertThatThrownBy(() -> underTest.update(input, USER))
                                 .isInstanceOf(BusinessException.class)
                                 .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+        }
+
+        @Test
+        public void update_databaseErrorWithNullMessage_shouldRethrowTechnicalException() {
+                final DsbMannschaftDO input = getDsbMannschaftDO();
+                final DsbMannschaftBE existingBE = getDsbMannschaftBE();
+
+                final TechnicalException expectedException = new TechnicalException(ErrorCode.DATABASE_ERROR,
+                                "placeholder message") {
+                        @Override
+                        public String getMessage() {
+                                return null;
+                        }
+                };
+
+                when(dsbMannschaftDAO.findById(anyLong())).thenReturn(existingBE);
+                when(dsbMannschaftDAO.update(any(DsbMannschaftBE.class), anyLong()))
+                                .thenThrow(expectedException);
+
+                try {
+                        underTest.update(input, USER);
+                        Assertions.fail("Expected TechnicalException to be thrown");
+                } catch (TechnicalException actualException) {
+                        assertThat(actualException).isSameAs(expectedException);
+                }
         }
 
     @Test


### PR DESCRIPTION
Adjusted user query to use LEFT JOIN so that users without assigned roles are also returned and displayed in the overview.

Tested by simulating a user without a role and verifying that the user is still visible in the list.