### PR TITLE
[epic-6] BSAPP-1969 and BSAPP-1926 backend verein fixes

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/dsbmannschaft/impl/dao/DsbMannschaftDAOext.java
@@ -124,7 +124,15 @@ public class DsbMannschaftDAOext implements DataAccessObject {
                     + " LEFT JOIN "
                     + " verein v ON m.mannschaft_verein_id = v.verein_id "
                     + " WHERE mannschaft_verein_id = ? "
-                    + " ORDER BY mannschaft_nummer ";
+                    + " AND ("
+                    + "   m.mannschaft_veranstaltung_id IS NULL "
+                    + "   OR EXISTS ("
+                    + "     SELECT 1 FROM veranstaltung ver "
+                    + "     WHERE ver.veranstaltung_id = m.mannschaft_veranstaltung_id "
+                    + "     AND (ver.veranstaltung_phase IS NULL OR ver.veranstaltung_phase IN (1, 2))"
+                    + "   )"
+                    + " )"
+                    + " ORDER BY mannschaft_nummer";
 
     private static final String FIND_ALL_BY_NAME_WITH_NAME =
             " SELECT "
@@ -229,7 +237,7 @@ public class DsbMannschaftDAOext implements DataAccessObject {
 
     public FileChannel findById(long teamId) {
         // TODO
-        
+
         return null;
     }
 

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImpl.java
@@ -12,6 +12,9 @@ import de.bogenliga.application.business.vereine.api.types.VereinDO;
 import de.bogenliga.application.business.vereine.impl.dao.VereinDAO;
 import de.bogenliga.application.business.vereine.impl.entity.VereinBE;
 import de.bogenliga.application.business.vereine.impl.mapper.VereinMapper;
+import de.bogenliga.application.common.errorhandling.ErrorCode;
+import de.bogenliga.application.common.errorhandling.exception.BusinessException;
+import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
 import de.bogenliga.application.common.validation.Preconditions;
 
 
@@ -30,6 +33,9 @@ public class VereinComponentImpl implements VereinComponent {
     private static final String PRECONDITION_MSG_VEREIN_REGION_ID = "VereinDO region id must not be null";
     private static final String PRECONDITION_MSG_VEREIN_REGION_ID_NOT_NEG = "VereinDO region id must not be negative";
     private static final String PRECONDITION_MSG_VEREIN_DSB_MITGLIED_NOT_NEG = "DsbMitglied id must not be negative";
+    private static final String DUPLICATE_VEREIN_DSB_IDENTIFIER_CONSTRAINT = "uc_verein_dsb_identifier";
+    private static final String DUPLICATE_VEREIN_NAME_CONSTRAINT = "uc_verein_name";
+    private static final String EXCEPTION_DUPLICATE_VEREIN = "Duplicate Verein";
 
     private final VereinDAO vereinDAO;
     private final VereinDAOext vereinDAOext;
@@ -61,7 +67,15 @@ public class VereinComponentImpl implements VereinComponent {
         checkVereinDO(vereinDO, currentDsbMitglied);
 
         final VereinBE vereinBE = VereinMapper.toVereinBE.apply(vereinDO);
-        final VereinBE persistedVereinBE = vereinDAO.create(vereinBE, currentDsbMitglied);
+        final VereinBE persistedVereinBE;
+        try {
+            persistedVereinBE = vereinDAO.create(vereinBE, currentDsbMitglied);
+        } catch (TechnicalException e) {
+            if (isDuplicateVereinConflict(e)) {
+                throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, EXCEPTION_DUPLICATE_VEREIN);
+            }
+            throw e;
+        }
 
         return VereinMapper.toVereinDO.apply(persistedVereinBE);
     }
@@ -78,7 +92,15 @@ public class VereinComponentImpl implements VereinComponent {
         Preconditions.checkArgument(vereinDO.getId() >= 0, PRECONDITION_MSG_VEREIN_ID);
 
         final VereinBE vereinBE = VereinMapper.toVereinBE.apply(vereinDO);
-        final VereinBE persistedVereinBE = vereinDAO.update(vereinBE, currentDsbMitglied);
+        final VereinBE persistedVereinBE;
+        try {
+            persistedVereinBE = vereinDAO.update(vereinBE, currentDsbMitglied);
+        } catch (TechnicalException e) {
+            if (isDuplicateVereinConflict(e)) {
+                throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, EXCEPTION_DUPLICATE_VEREIN);
+            }
+            throw e;
+        }
         return VereinMapper.toVereinDO.apply(persistedVereinBE);
     }
 
@@ -101,6 +123,13 @@ public class VereinComponentImpl implements VereinComponent {
         Preconditions.checkNotNull(vereinDO.getRegionId(), PRECONDITION_MSG_VEREIN_REGION_ID);
 
         Preconditions.checkArgument(vereinDO.getRegionId() >= 0, PRECONDITION_MSG_VEREIN_REGION_ID_NOT_NEG);
+    }
+
+    private boolean isDuplicateVereinConflict(final TechnicalException e) {
+        return e.getErrorCode() == ErrorCode.DATABASE_ERROR
+                && e.getMessage() != null
+                && (e.getMessage().contains(DUPLICATE_VEREIN_DSB_IDENTIFIER_CONSTRAINT)
+                || e.getMessage().contains(DUPLICATE_VEREIN_NAME_CONSTRAINT));
     }
 
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
@@ -225,6 +225,31 @@ public class VereinComponentImplTest {
     }
 
     @Test
+    public void create_duplicateVereinNameConstraint_shouldThrowConflict() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.create(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                        "duplicate key value violates unique constraint \"uc_verein_name\""));
+
+        assertThatThrownBy(() -> underTest.create(input, USER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+    }
+
+    @Test
+    public void create_nonDuplicateDatabaseError_shouldRethrowTechnicalException() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.create(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR, "other database error"));
+
+        assertThatThrownBy(() -> underTest.create(input, USER))
+                .isInstanceOf(TechnicalException.class)
+                .hasMessageContaining("other database error");
+    }
+
+    @Test
     public void update() {
         // prepare test data
         final VereinDO input = getVereinDO();
@@ -269,6 +294,31 @@ public class VereinComponentImplTest {
         assertThatThrownBy(() -> underTest.update(input, USER))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+    }
+
+    @Test
+    public void update_duplicateVereinNameConstraint_shouldThrowConflict() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.update(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                        "duplicate key value violates unique constraint \"uc_verein_name\""));
+
+        assertThatThrownBy(() -> underTest.update(input, USER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+    }
+
+    @Test
+    public void update_nonDuplicateDatabaseError_shouldRethrowTechnicalException() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.update(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR, "other database error"));
+
+        assertThatThrownBy(() -> underTest.update(input, USER))
+                .isInstanceOf(TechnicalException.class)
+                .hasMessageContaining("other database error");
     }
 
     @Test

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/vereine/impl/business/VereinComponentImplTest.java
@@ -6,6 +6,9 @@ import de.bogenliga.application.business.vereine.impl.dao.VereinDAO;
 import de.bogenliga.application.business.vereine.impl.dao.VereinDAOext;
 import de.bogenliga.application.business.vereine.impl.entity.VereinBE;
 import de.bogenliga.application.business.vereine.impl.entity.VereinBEext;
+import de.bogenliga.application.common.errorhandling.ErrorCode;
+import de.bogenliga.application.common.errorhandling.exception.BusinessException;
+import de.bogenliga.application.common.errorhandling.exception.TechnicalException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -206,6 +210,20 @@ public class VereinComponentImplTest {
         assertThat(persistedBE.getVereinId())
                 .isEqualTo(input.getId());
     }
+
+    @Test
+    public void create_duplicateVereinConstraint_shouldThrowConflict() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.create(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                        "duplicate key value violates unique constraint \"uc_verein_dsb_identifier\""));
+
+        assertThatThrownBy(() -> underTest.create(input, USER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
+    }
+
     @Test
     public void update() {
         // prepare test data
@@ -238,6 +256,19 @@ public class VereinComponentImplTest {
                 .isEqualTo(input.getId());
         assertThat(persistedBE.getVereinName())
                 .isEqualTo(input.getName());
+    }
+
+    @Test
+    public void update_duplicateVereinConstraint_shouldThrowConflict() {
+        final VereinDO input = getVereinDO();
+
+        when(vereinDAO.update(any(VereinBE.class), anyLong()))
+                .thenThrow(new TechnicalException(ErrorCode.DATABASE_ERROR,
+                        "duplicate key value violates unique constraint \"uc_verein_dsb_identifier\""));
+
+        assertThatThrownBy(() -> underTest.update(input, USER))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.ENTITY_CONFLICT_ERROR.getValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep the existing BSAPP-1969 phase-3 filter change on `feature/epic-6`
- add the backend conflict mapping for BSAPP-1926 in the verein flow
- return a business conflict instead of a raw database error for duplicate verein data

## What Changed
- map duplicate verein constraint violations (`uc_verein_dsb_identifier`, `uc_verein_name`) to `ENTITY_CONFLICT_ERROR`
- apply the mapping in both `create` and `update` inside `VereinComponentImpl`
- add regression tests for duplicate verein conflicts in `VereinComponentImplTest`
- retain the already existing phase filter work on this branch for the verein overview

## Why
Ticket BSAPP-1926 originally focused on duplicate handling around verein/mannschaft administration. While the mannschaft flow had already been improved, the verein backend still surfaced duplicate data as a technical database error. That prevented the frontend from showing a proper conflict message and contributed to the confusing save flow.

## Impact
- duplicate verein data now produces a semantic business conflict
- the frontend can distinguish duplicate input from generic database failures
- the backend behavior is covered by focused tests for create and update

## Validation
- `./mvnw -q -pl bogenliga-business-logic -am -DfailIfNoTests=false -Dtest=VereinComponentImplTest test`
