### PR TITLE
fix: maintain consistent Schusszettel layout when no tablet session e…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/api/SchusszettelComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/api/SchusszettelComponentImpl.java
@@ -1049,6 +1049,9 @@ public class SchusszettelComponentImpl implements SchusszettelComponent {
             if (qrImage != null) {
                 qrCell.add(qrImage.setWidth(50).setHeight(50)
                         .setHorizontalAlignment(com.itextpdf.layout.property.HorizontalAlignment.RIGHT));
+            } else {
+                // Placeholder keeps same height as QR image so tableThirdRow rows don't expand
+                qrCell.add(new com.itextpdf.layout.element.Div().setWidth(50).setHeight(50));
             }
 
             if(dsbMannschaftComponent.findById(matchDOs[0].getMannschaftId()).getVereinId() == PLATZHALTER_ID){


### PR DESCRIPTION
…xists

  Without a QR image, the spanning qrCell had no content, causing iText to
  expand each row in tableThirdRow to its default minimum height. This made
  the second Schusszettel half overflow its bordered Div, pushing the
  Unterschrift row onto a separate page. A fixed 50×50 Div placeholder now
  ensures the same row height as the QR image.