### PR TITLE
#2144

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -138,5 +138,14 @@ public class AnzeigenService implements ServiceFacade {
         return AnzeigenDTOMapper.toDTO.apply(updatedAnzeigenDO);
     }
 
+    @PutMapping(
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_SYSTEMDATEN})
+    public String getNewPhysischeBildschirmID(@RequestBody final Principal principal) {
+        return anzeigenComponent.generatePhysischeBildschirmId();
+    }
+
+
+
 
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -1,7 +1,9 @@
 package de.bogenliga.application.services.v1.wettkampf.service;
 
 import java.security.Principal;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import de.bogenliga.application.business.wettkampf.api.AnzeigenComponent;
 import de.bogenliga.application.business.wettkampf.api.types.AnzeigenDO;
@@ -138,11 +140,13 @@ public class AnzeigenService implements ServiceFacade {
         return AnzeigenDTOMapper.toDTO.apply(updatedAnzeigenDO);
     }
 
-    @PutMapping(
+    @GetMapping(
+            value = "getNewPhysischeBildschirmID",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_SYSTEMDATEN})
-    public String getNewPhysischeBildschirmID(@RequestBody final Principal principal) {
-        return anzeigenComponent.generatePhysischeBildschirmId();
+    public Map<String, String> getNewPhysischeBildschirmID(final Principal principal) {
+        String randomId = anzeigenComponent.generatePhysischeBildschirmId();
+        return Collections.singletonMap("id", randomId);
     }
 
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -143,8 +143,7 @@ public class AnzeigenService implements ServiceFacade {
     @GetMapping(
             value = "getNewPhysischeBildschirmID",
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_SYSTEMDATEN})
-    public Map<String, String> getNewPhysischeBildschirmID(final Principal principal) {
+    public Map<String, String> getNewPhysischeBildschirmID() {
         String randomId = anzeigenComponent.generatePhysischeBildschirmId();
         return Collections.singletonMap("id", randomId);
     }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/anzeigen/AnzeigenServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/anzeigen/AnzeigenServiceTest.java
@@ -167,4 +167,29 @@ public class AnzeigenServiceTest {
 
         assertThat(userIdCaptor.getValue()).isEqualTo(99L);
     }
+
+    @Test
+    public void getNewPhysischeBildschirmID_shouldReturnGeneratedIdInMap() {
+        final String generatedId = "Ab1C";
+        when(anzeigenComponent.generatePhysischeBildschirmId()).thenReturn(generatedId);
+
+        java.util.Map<String, String> result = underTest.getNewPhysischeBildschirmID();
+
+        assertThat(result)
+                .isNotNull()
+                .hasSize(1)
+                .containsEntry("id", generatedId);
+
+        verify(anzeigenComponent).generatePhysischeBildschirmId();
+    }
+
+    @Test
+    public void getNewPhysischeBildschirmID_shouldDelegateToComponent() {
+        when(anzeigenComponent.generatePhysischeBildschirmId()).thenReturn("Z9z0");
+
+        underTest.getNewPhysischeBildschirmID();
+
+        verify(anzeigenComponent, times(1)).generatePhysischeBildschirmId();
+        verifyNoMoreInteractions(anzeigenComponent);
+    }
 }


### PR DESCRIPTION
Das Ticket enthält die Änderungen im Backend, die es gebraucht hat um die Physische Bildschirm ID vom Backend ins Frontend zu bringen. 

Dafür gibt es eine neue Funktion im "bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java" namens
"getNewPhysischeBildschirmID()"

und in "bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/anzeigen/AnzeigenServiceTest.java" gibts zwei Tests dazu, die auch laufen