### PR TITLE
feat(dsbmannschaft): laufende Veranstaltung serverseitig gegen Mannsc…

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -71,6 +71,8 @@ public class DsbMannschaftService implements ServiceFacade {
     private static final String ERROR_MSG_PLATZHALTER_NO_PERMISSION = "Sie haben keine Berechtigung für diese Aktion.";
     private static final String ERROR_MSG_DELETE_MANNSCHAFT_NO_PERMISSION = "Löschen einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
     private static final String ERROR_MSG_UPDATE_MANNSCHAFT_NO_PERMISSION = "Ändern einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
+    private static final String ERROR_MSG_VERANSTALTUNG_LAUFEND = "Die Veranstaltung ist in der Phase 'Laufend'. Teilnehmende Mannschaften können in dieser Phase nicht hinzugefügt, geändert oder entfernt werden.";
+    private static final String VERANSTALTUNG_PHASE_LAUFEND = "Laufend";
 
     MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
 
@@ -334,6 +336,9 @@ public class DsbMannschaftService implements ServiceFacade {
             final Long userId = UserProvider.getCurrentUserId(principal);
             Preconditions.checkArgument(userId >= 0, PRECONDITION_MSG_DSBMANNSCHAFT_BENUTZER_ID_NEGATIVE);
 
+            // Bei laufender Veranstaltung duerfen keine Mannschaften (auch keine Platzhalter) angelegt werden.
+            assertVeranstaltungNotLaufend(dsbMannschaftDTO.getVeranstaltungId());
+
             // Check size of Veranstaltung and if it is full
             // If Veranstaltung does not exist choose 8 as its default size
             if(dsbMannschaftDTO.getVereinId().equals(PLATZHALTER_VEREIN_ID)) {
@@ -531,6 +536,8 @@ public class DsbMannschaftService implements ServiceFacade {
             throw new NoPermissionException();
         }
 
+        // Bei laufender Veranstaltung duerfen keine Mannschaften zugeordnet werden.
+        assertVeranstaltungNotLaufend(veranstaltungsId);
 
         dsbMannschaftDO.setVeranstaltungId(veranstaltungsId);
         VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
@@ -556,6 +563,9 @@ public class DsbMannschaftService implements ServiceFacade {
 
         DsbMannschaftDO dsbMannschaftDO = dsbMannschaftComponent.findById(mannschaftId);
 
+        // Bei laufender Veranstaltung darf die Zuordnung der Mannschaft nicht entfernt werden.
+        assertVeranstaltungNotLaufend(dsbMannschaftDO.getVeranstaltungId());
+
         // Prüfen, ob die Veranstaltung in der Phase "geplant" ist -
         // nur dann können wir löschen, ohne dass Daten verloren gehen könnten...
         // das Sportjahr wird immer parallel gelöscht/gesetzt
@@ -568,6 +578,26 @@ public class DsbMannschaftService implements ServiceFacade {
                 DsbMannschaftDO neueMannschaft = dsbMannschaftComponent.update(dsbMannschaftDO, userId);
                 LOG.debug("Mannschaft '{}'  aus Veranstaltung mit id '{}' entfernt.", neueMannschaft.getName(), veranstaltungDO.getVeranstaltungID());
             }
+        }
+    }
+
+    /**
+     * Stellt sicher, dass die Veranstaltung nicht in der Phase 'Laufend' ist.
+     * In dieser Phase duerfen teilnehmende Mannschaften weder hinzugefuegt noch
+     * entfernt oder umsortiert werden (serverseitige Absicherung der UI-Sperre
+     * aus Ticket swt2#2157, vgl. swt2#2229). Bei {@code null} (keine Veranstaltung
+     * zugeordnet) passiert nichts.
+     *
+     * @param veranstaltungsId id der zu pruefenden Veranstaltung (darf null sein)
+     * @throws BusinessException wenn die Veranstaltung in der Phase 'Laufend' ist
+     */
+    private void assertVeranstaltungNotLaufend(final Long veranstaltungsId) {
+        if (veranstaltungsId == null) {
+            return;
+        }
+        final VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
+        if (veranstaltungDO != null && VERANSTALTUNG_PHASE_LAUFEND.equals(veranstaltungDO.getVeranstaltungPhase())) {
+            throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
         }
     }
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -535,11 +535,11 @@ public class DsbMannschaftService implements ServiceFacade {
             throw new NoPermissionException();
         }
 
-        // Bei laufender Veranstaltung duerfen keine Mannschaften zugeordnet werden.
-        assertVeranstaltungNotLaufend(veranstaltungsId);
-
         dsbMannschaftDO.setVeranstaltungId(veranstaltungsId);
         VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
+        // Bei laufender Veranstaltung duerfen keine Mannschaften zugeordnet werden
+        // (Pruefung auf dem bereits geladenen DO -> kein erneutes findById).
+        assertVeranstaltungNotLaufend(veranstaltungDO);
         dsbMannschaftDO.setSportjahr(veranstaltungDO.getVeranstaltungSportJahr());
 
         DsbMannschaftDO neueMannschaft = dsbMannschaftComponent.update(dsbMannschaftDO, userId);
@@ -592,6 +592,13 @@ public class DsbMannschaftService implements ServiceFacade {
      */
     private void assertVeranstaltungNotLaufend(final Long veranstaltungsId) {
         if (veranstaltungsId != null && veranstaltungComponent.isVeranstaltungLaufend(veranstaltungsId)) {
+            throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
+        }
+    }
+
+    /** Variante fuer eine bereits geladene Veranstaltung (vermeidet erneutes findById). */
+    private void assertVeranstaltungNotLaufend(final VeranstaltungDO veranstaltung) {
+        if (veranstaltungComponent.isVeranstaltungLaufend(veranstaltung)) {
             throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
         }
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftService.java
@@ -72,7 +72,6 @@ public class DsbMannschaftService implements ServiceFacade {
     private static final String ERROR_MSG_DELETE_MANNSCHAFT_NO_PERMISSION = "Löschen einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
     private static final String ERROR_MSG_UPDATE_MANNSCHAFT_NO_PERMISSION = "Ändern einer Mannschaft ist nur mit entsprechender Berechtigung erlaubt.";
     private static final String ERROR_MSG_VERANSTALTUNG_LAUFEND = "Die Veranstaltung ist in der Phase 'Laufend'. Teilnehmende Mannschaften können in dieser Phase nicht hinzugefügt, geändert oder entfernt werden.";
-    private static final String VERANSTALTUNG_PHASE_LAUFEND = "Laufend";
 
     MannschaftsmitgliedComponent mannschaftsmitgliedComponent;
 
@@ -592,11 +591,7 @@ public class DsbMannschaftService implements ServiceFacade {
      * @throws BusinessException wenn die Veranstaltung in der Phase 'Laufend' ist
      */
     private void assertVeranstaltungNotLaufend(final Long veranstaltungsId) {
-        if (veranstaltungsId == null) {
-            return;
-        }
-        final VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
-        if (veranstaltungDO != null && VERANSTALTUNG_PHASE_LAUFEND.equals(veranstaltungDO.getVeranstaltungPhase())) {
+        if (veranstaltungsId != null && veranstaltungComponent.isVeranstaltungLaufend(veranstaltungsId)) {
             throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
         }
     }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
@@ -1,7 +1,12 @@
 package de.bogenliga.application.services.v1.dsbmannschaft.service;
 
+import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftSortierungComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
+import de.bogenliga.application.common.errorhandling.ErrorCode;
+import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.service.UserProvider;
 import de.bogenliga.application.common.validation.Preconditions;
@@ -25,6 +30,8 @@ public class MannschaftSortierungService implements ServiceFacade {
     private static final String PRECONDITION_MSG_DSBMANNSCHAFT_DO = "DsbMannschaftDO must not be null";
     private static final String PRECONDITION_MSG_DSBMANNSCHAFT_ID = "DsbMannschaft-ID must not be null or less than 0";
     private static final String PRECONDITION_MSG_DSBMANNSCHAFT_SORTIERUNG = "DsbMannschaft-Sortierung must not be null or less than 0";
+    private static final String ERROR_MSG_VERANSTALTUNG_LAUFEND = "Die Veranstaltung ist in der Phase 'Laufend'. Der Tabellenplatz teilnehmender Mannschaften kann in dieser Phase nicht geändert werden.";
+    private static final String VERANSTALTUNG_PHASE_LAUFEND = "Laufend";
 
     private static final Logger LOG = LoggerFactory.getLogger(MannschaftSortierungService.class);
 
@@ -34,16 +41,24 @@ public class MannschaftSortierungService implements ServiceFacade {
      * dependency injection with {@link Autowired}
      */
     private final DsbMannschaftSortierungComponent maSortierungComponent;
+    private final DsbMannschaftComponent dsbMannschaftComponent;
+    private final VeranstaltungComponent veranstaltungComponent;
 
 
     /**
      * Constructor with dependency injection
      *
      * @param maSortierungComponent to handle the database CRUD requests
+     * @param dsbMannschaftComponent to resolve the Veranstaltung of a Mannschaft
+     * @param veranstaltungComponent to read the phase of the Veranstaltung
      */
     @Autowired
-    public MannschaftSortierungService(final DsbMannschaftSortierungComponent maSortierungComponent) {
+    public MannschaftSortierungService(final DsbMannschaftSortierungComponent maSortierungComponent,
+                                       final DsbMannschaftComponent dsbMannschaftComponent,
+                                       final VeranstaltungComponent veranstaltungComponent) {
         this.maSortierungComponent = maSortierungComponent;
+        this.dsbMannschaftComponent = dsbMannschaftComponent;
+        this.veranstaltungComponent = veranstaltungComponent;
     }
 
 
@@ -61,10 +76,31 @@ public class MannschaftSortierungService implements ServiceFacade {
         LOG.debug("Receive 'update' request with Mannschafts-ID '{}' and Mannschafts-Sortierung '{}'.",
                 maSortierungDTO.getId(), maSortierungDTO.getSortierung());
 
+        // Bei laufender Veranstaltung darf der Tabellenplatz nicht geaendert werden.
+        final DsbMannschaftDO existingMannschaft = dsbMannschaftComponent.findById(maSortierungDTO.getId());
+        assertVeranstaltungNotLaufend(existingMannschaft.getVeranstaltungId());
+
         final DsbMannschaftDO newDsbMannschaftDO = MannschaftSortierungDTOMapper.toDO.apply(maSortierungDTO);
         final long userId = UserProvider.getCurrentUserId(principal);
 
         final DsbMannschaftDO updatedDsbMannschaftDO = maSortierungComponent.updateSortierung(newDsbMannschaftDO, userId);
         return MannschaftSortierungDTOMapper.toDTO.apply(updatedDsbMannschaftDO);
+    }
+
+    /**
+     * Stellt sicher, dass die Veranstaltung nicht in der Phase 'Laufend' ist.
+     * Bei {@code null} (keine Veranstaltung zugeordnet) passiert nichts.
+     *
+     * @param veranstaltungsId id der zu pruefenden Veranstaltung (darf null sein)
+     * @throws BusinessException wenn die Veranstaltung in der Phase 'Laufend' ist
+     */
+    private void assertVeranstaltungNotLaufend(final Long veranstaltungsId) {
+        if (veranstaltungsId == null) {
+            return;
+        }
+        final VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
+        if (veranstaltungDO != null && VERANSTALTUNG_PHASE_LAUFEND.equals(veranstaltungDO.getVeranstaltungPhase())) {
+            throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
+        }
     }
 }

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungService.java
@@ -4,7 +4,6 @@ import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponen
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftSortierungComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
-import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
 import de.bogenliga.application.common.errorhandling.ErrorCode;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import de.bogenliga.application.common.service.ServiceFacade;
@@ -31,7 +30,6 @@ public class MannschaftSortierungService implements ServiceFacade {
     private static final String PRECONDITION_MSG_DSBMANNSCHAFT_ID = "DsbMannschaft-ID must not be null or less than 0";
     private static final String PRECONDITION_MSG_DSBMANNSCHAFT_SORTIERUNG = "DsbMannschaft-Sortierung must not be null or less than 0";
     private static final String ERROR_MSG_VERANSTALTUNG_LAUFEND = "Die Veranstaltung ist in der Phase 'Laufend'. Der Tabellenplatz teilnehmender Mannschaften kann in dieser Phase nicht geändert werden.";
-    private static final String VERANSTALTUNG_PHASE_LAUFEND = "Laufend";
 
     private static final Logger LOG = LoggerFactory.getLogger(MannschaftSortierungService.class);
 
@@ -95,11 +93,7 @@ public class MannschaftSortierungService implements ServiceFacade {
      * @throws BusinessException wenn die Veranstaltung in der Phase 'Laufend' ist
      */
     private void assertVeranstaltungNotLaufend(final Long veranstaltungsId) {
-        if (veranstaltungsId == null) {
-            return;
-        }
-        final VeranstaltungDO veranstaltungDO = veranstaltungComponent.findById(veranstaltungsId);
-        if (veranstaltungDO != null && VERANSTALTUNG_PHASE_LAUFEND.equals(veranstaltungDO.getVeranstaltungPhase())) {
+        if (veranstaltungsId != null && veranstaltungComponent.isVeranstaltungLaufend(veranstaltungsId)) {
             throw new BusinessException(ErrorCode.ENTITY_CONFLICT_ERROR, ERROR_MSG_VERANSTALTUNG_LAUFEND);
         }
     }

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -868,6 +868,69 @@ public class DsbMannschaftServiceTest {
 
 
     @Test
+    public void assignMannschaftToVeranstaltung_VeranstaltungLaufend_expectException() {
+        // Prepare test data: Ziel-Veranstaltung ist 'Laufend'
+        final DsbMannschaftDO mannschaftDO = getDsbMannschaftDO();
+        final long inputVeranstaltungsId = 222L;
+        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
+        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
+
+        // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(mannschaftDO);
+        when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(true);
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+
+        // call + assert: bei laufender Veranstaltung wird die Zuordnung abgelehnt
+        assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> underTest.assignMannschaftToVeranstaltung(inputVeranstaltungsId, mannschaftDO.getId(), principal))
+                .withMessageContaining("Laufend");
+
+        // es darf nichts gespeichert werden
+        verify(dsbMannschaftComponent, times(0)).update(any(), anyLong());
+    }
+
+    @Test
+    public void unassignMannschaftFromVeranstaltung_VeranstaltungLaufend_expectException() {
+        // Prepare test data: Mannschaft gehoert zu einer laufenden Veranstaltung
+        final DsbMannschaftDO mannschaftDO = getDsbMannschaftDO();
+        mannschaftDO.setVeranstaltungId(222L);
+        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
+        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
+
+        // configure mocks
+        when(dsbMannschaftComponent.findById(anyLong())).thenReturn(mannschaftDO);
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+
+        // call + assert: bei laufender Veranstaltung wird das Entfernen abgelehnt
+        assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> underTest.unassignMannschaftFromVeranstaltung(mannschaftDO.getId(), principal))
+                .withMessageContaining("Laufend");
+
+        verify(dsbMannschaftComponent, times(0)).update(any(), anyLong());
+    }
+
+    @Test
+    public void create_VeranstaltungLaufend_expectException() {
+        // Prepare test data: Ziel-Veranstaltung ist 'Laufend'
+        final DsbMannschaftDTO input = getDsbMannschaftDTO();
+        input.setVeranstaltungId(222L);
+        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
+        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
+
+        // configure mocks
+        when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+
+        // call + assert: bei laufender Veranstaltung wird das Anlegen abgelehnt
+        assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> underTest.create(input, principal))
+                .withMessageContaining("Laufend");
+
+        // es darf keine Mannschaft angelegt werden
+        verify(dsbMannschaftComponent, times(0)).create(any(), anyLong());
+    }
+
+    @Test
     public void testEqualsAndHashCode() {
         // Arrange
         DsbMannschaftDO dsbMannschaftDO1 = getDsbMannschaftDO();

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -873,10 +873,11 @@ public class DsbMannschaftServiceTest {
         final DsbMannschaftDO mannschaftDO = getDsbMannschaftDO();
         final long inputVeranstaltungsId = 222L;
 
-        // configure mocks
+        // configure mocks (assign laedt das Veranstaltungs-DO einmal und prueft darauf)
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(mannschaftDO);
         when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(true);
-        when(veranstaltungComponent.isVeranstaltungLaufend(anyLong())).thenReturn(true);
+        when(veranstaltungComponent.findById(anyLong())).thenReturn(getVeranstaltungDO());
+        when(veranstaltungComponent.isVeranstaltungLaufend(any(VeranstaltungDO.class))).thenReturn(true);
 
         // call + assert: bei laufender Veranstaltung wird die Zuordnung abgelehnt
         assertThatExceptionOfType(BusinessException.class)

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/DsbMannschaftServiceTest.java
@@ -872,13 +872,11 @@ public class DsbMannschaftServiceTest {
         // Prepare test data: Ziel-Veranstaltung ist 'Laufend'
         final DsbMannschaftDO mannschaftDO = getDsbMannschaftDO();
         final long inputVeranstaltungsId = 222L;
-        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
-        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
 
         // configure mocks
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(mannschaftDO);
         when(requiresOnePermissionAspect.hasSpecificPermissionLigaLeiterID(any(), anyLong())).thenReturn(true);
-        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+        when(veranstaltungComponent.isVeranstaltungLaufend(anyLong())).thenReturn(true);
 
         // call + assert: bei laufender Veranstaltung wird die Zuordnung abgelehnt
         assertThatExceptionOfType(BusinessException.class)
@@ -894,12 +892,10 @@ public class DsbMannschaftServiceTest {
         // Prepare test data: Mannschaft gehoert zu einer laufenden Veranstaltung
         final DsbMannschaftDO mannschaftDO = getDsbMannschaftDO();
         mannschaftDO.setVeranstaltungId(222L);
-        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
-        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
 
         // configure mocks
         when(dsbMannschaftComponent.findById(anyLong())).thenReturn(mannschaftDO);
-        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+        when(veranstaltungComponent.isVeranstaltungLaufend(anyLong())).thenReturn(true);
 
         // call + assert: bei laufender Veranstaltung wird das Entfernen abgelehnt
         assertThatExceptionOfType(BusinessException.class)
@@ -914,12 +910,10 @@ public class DsbMannschaftServiceTest {
         // Prepare test data: Ziel-Veranstaltung ist 'Laufend'
         final DsbMannschaftDTO input = getDsbMannschaftDTO();
         input.setVeranstaltungId(222L);
-        final VeranstaltungDO laufendVeranstaltung = getVeranstaltungDO();
-        laufendVeranstaltung.setVeranstaltungPhase("Laufend");
 
         // configure mocks
         when(requiresOnePermissionAspect.hasPermission(any())).thenReturn(true);
-        when(veranstaltungComponent.findById(anyLong())).thenReturn(laufendVeranstaltung);
+        when(veranstaltungComponent.isVeranstaltungLaufend(anyLong())).thenReturn(true);
 
         // call + assert: bei laufender Veranstaltung wird das Anlegen abgelehnt
         assertThatExceptionOfType(BusinessException.class)

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
@@ -4,7 +4,6 @@ import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponen
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftSortierungComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
 import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
-import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.MannschaftSortierungDTO;
 import org.junit.Before;
@@ -82,13 +81,6 @@ public class MannschaftSortierungServiceTest {
     }
 
 
-    private static VeranstaltungDO getVeranstaltungDO(final String phase) {
-        final VeranstaltungDO veranstaltungDO = new VeranstaltungDO();
-        veranstaltungDO.setVeranstaltungPhase(phase);
-        return veranstaltungDO;
-    }
-
-
     @Before
     public void initMocks() {
         when(principal.getName()).thenReturn(String.valueOf(USER));
@@ -104,7 +96,7 @@ public class MannschaftSortierungServiceTest {
 
         // configure mocks
         when(dsbMannschaftComponent.findById(ID)).thenReturn(getDsbMannschaftDO());
-        when(veranstaltungComponent.findById(DB_VERANSTALTUNG_ID)).thenReturn(getVeranstaltungDO("Geplant"));
+        when(veranstaltungComponent.isVeranstaltungLaufend(DB_VERANSTALTUNG_ID)).thenReturn(false);
         when(mannschaftSortierungComponent.updateSortierung(any(), anyLong())).thenReturn(expected);
 
         // call test method
@@ -132,7 +124,7 @@ public class MannschaftSortierungServiceTest {
 
         // configure mocks: Mannschaft gehoert zu einer laufenden Veranstaltung
         when(dsbMannschaftComponent.findById(ID)).thenReturn(getDsbMannschaftDO());
-        when(veranstaltungComponent.findById(DB_VERANSTALTUNG_ID)).thenReturn(getVeranstaltungDO("Laufend"));
+        when(veranstaltungComponent.isVeranstaltungLaufend(DB_VERANSTALTUNG_ID)).thenReturn(true);
 
         // call test method + assert: bei laufender Veranstaltung wird abgelehnt
         assertThatExceptionOfType(BusinessException.class)

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
@@ -1,7 +1,10 @@
 package de.bogenliga.application.services.v1.dsbmannschaft.service;
 
+import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.DsbMannschaftSortierungComponent;
 import de.bogenliga.application.business.dsbmannschaft.api.types.DsbMannschaftDO;
+import de.bogenliga.application.business.veranstaltung.api.VeranstaltungComponent;
+import de.bogenliga.application.business.veranstaltung.api.types.VeranstaltungDO;
 import de.bogenliga.application.common.errorhandling.exception.BusinessException;
 import de.bogenliga.application.services.v1.dsbmannschaft.model.MannschaftSortierungDTO;
 import org.junit.Before;
@@ -45,6 +48,12 @@ public class MannschaftSortierungServiceTest {
     private DsbMannschaftSortierungComponent mannschaftSortierungComponent;
 
     @Mock
+    private DsbMannschaftComponent dsbMannschaftComponent;
+
+    @Mock
+    private VeranstaltungComponent veranstaltungComponent;
+
+    @Mock
     private Principal principal;
 
     @InjectMocks
@@ -73,6 +82,13 @@ public class MannschaftSortierungServiceTest {
     }
 
 
+    private static VeranstaltungDO getVeranstaltungDO(final String phase) {
+        final VeranstaltungDO veranstaltungDO = new VeranstaltungDO();
+        veranstaltungDO.setVeranstaltungPhase(phase);
+        return veranstaltungDO;
+    }
+
+
     @Before
     public void initMocks() {
         when(principal.getName()).thenReturn(String.valueOf(USER));
@@ -87,6 +103,8 @@ public class MannschaftSortierungServiceTest {
         final DsbMannschaftDO expected = getDsbMannschaftDO();
 
         // configure mocks
+        when(dsbMannschaftComponent.findById(ID)).thenReturn(getDsbMannschaftDO());
+        when(veranstaltungComponent.findById(DB_VERANSTALTUNG_ID)).thenReturn(getVeranstaltungDO("Geplant"));
         when(mannschaftSortierungComponent.updateSortierung(any(), anyLong())).thenReturn(expected);
 
         // call test method
@@ -105,6 +123,24 @@ public class MannschaftSortierungServiceTest {
         assertThat(updatedDsbMannschaft).isNotNull();
         assertThat(updatedDsbMannschaft.getId()).isEqualTo(inputDTO.getId());
         assertThat(updatedDsbMannschaft.getSortierung()).isEqualTo(inputDTO.getSortierung());
+    }
+
+    @Test
+    public void update_VeranstaltungLaufend_expectException() {
+        // prepare test data
+        final MannschaftSortierungDTO inputDTO = getMannschaftSortierungDTO();
+
+        // configure mocks: Mannschaft gehoert zu einer laufenden Veranstaltung
+        when(dsbMannschaftComponent.findById(ID)).thenReturn(getDsbMannschaftDO());
+        when(veranstaltungComponent.findById(DB_VERANSTALTUNG_ID)).thenReturn(getVeranstaltungDO("Laufend"));
+
+        // call test method + assert: bei laufender Veranstaltung wird abgelehnt
+        assertThatExceptionOfType(BusinessException.class)
+                .isThrownBy(() -> underTest.update(inputDTO, principal))
+                .withMessageContaining("Laufend");
+
+        // der Tabellenplatz darf NICHT gespeichert werden
+        verifyZeroInteractions(mannschaftSortierungComponent);
     }
 
     @Test

--- a/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
+++ b/bogenliga/bogenliga-application/src/test/java/de/bogenliga/application/services/v1/dsbmannschaft/service/MannschaftSortierungServiceTest.java
@@ -136,6 +136,30 @@ public class MannschaftSortierungServiceTest {
     }
 
     @Test
+    public void update_OhneVeranstaltung_laeuftDurch() {
+        // Mannschaft ohne zugeordnete Veranstaltung (veranstaltungId == null):
+        // die Phasenpruefung wird uebersprungen und das Update laeuft durch.
+        final MannschaftSortierungDTO inputDTO = getMannschaftSortierungDTO();
+        final DsbMannschaftDO expected = getDsbMannschaftDO();
+
+        final DsbMannschaftDO mannschaftOhneVeranstaltung = getDsbMannschaftDO();
+        mannschaftOhneVeranstaltung.setVeranstaltungId(null);
+
+        // configure mocks
+        when(dsbMannschaftComponent.findById(ID)).thenReturn(mannschaftOhneVeranstaltung);
+        when(mannschaftSortierungComponent.updateSortierung(any(), anyLong())).thenReturn(expected);
+
+        // call test method
+        final MannschaftSortierungDTO actual = underTest.update(inputDTO, principal);
+
+        // assert: updateSortierung wurde ausgefuehrt, keine Phasenpruefung noetig
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isEqualTo(inputDTO.getId());
+        verify(mannschaftSortierungComponent).updateSortierung(any(), anyLong());
+        verify(veranstaltungComponent, never()).isVeranstaltungLaufend(anyLong());
+    }
+
+    @Test
     public void update_WrongValueSortierung_expectException() {
         // prepare test data
         final MannschaftSortierungDTO inputDTO = getMannschaftSortierungDTO();

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/api/VeranstaltungComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/api/VeranstaltungComponent.java
@@ -135,4 +135,14 @@ public interface VeranstaltungComponent extends ComponentFacade {
     VeranstaltungDO setPhase(final long veranstaltungId, String phase, long currentDsbMitgliedId );
 
 
+    /**
+     * Prueft fachlich, ob sich eine Veranstaltung in der Phase 'Laufend' befindet.
+     * Verglichen wird der numerische Phasenwert (robuster als das String-Label).
+     * Existiert die Veranstaltung nicht, wird {@code false} geliefert.
+     *
+     * @param veranstaltungId id der zu pruefenden Veranstaltung
+     * @return {@code true}, wenn die Veranstaltung in der Phase 'Laufend' ist
+     */
+    boolean isVeranstaltungLaufend(final long veranstaltungId);
+
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/api/VeranstaltungComponent.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/api/VeranstaltungComponent.java
@@ -145,4 +145,13 @@ public interface VeranstaltungComponent extends ComponentFacade {
      */
     boolean isVeranstaltungLaufend(final long veranstaltungId);
 
+    /**
+     * Wie {@link #isVeranstaltungLaufend(long)}, jedoch fuer eine bereits geladene
+     * Veranstaltung – vermeidet ein erneutes Laden, wenn das DO schon vorliegt.
+     *
+     * @param veranstaltung bereits geladene Veranstaltung (darf null sein)
+     * @return {@code true}, wenn die Veranstaltung in der Phase 'Laufend' ist
+     */
+    boolean isVeranstaltungLaufend(final VeranstaltungDO veranstaltung);
+
 }

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImpl.java
@@ -98,6 +98,21 @@ public class VeranstaltungComponentImpl implements VeranstaltungComponent {
         return VeranstaltungMapper.toVeranstaltungDOext(result);
     }
 
+    /** Numerischer Phasenwert fuer 'Laufend' (zentral aus {@link VeranstaltungPhase}). */
+    private static final int PHASE_LAUFEND = new VeranstaltungPhase().getPhaseAsInt(VeranstaltungPhase.Phase.LAUFEND);
+
+    @Override
+    public boolean isVeranstaltungLaufend(final long veranstaltungId) {
+        Preconditions.checkArgument(veranstaltungId >= 0, PRECONDITION_MSG_VERANSTALTUNG_ID);
+
+        // Direkt auf der BE den numerischen Phasenwert vergleichen (robuster als das
+        // String-Label). Null-safe: existiert die Veranstaltung nicht, ist sie nicht 'Laufend'.
+        final VeranstaltungBEext result = veranstaltungDAOext.findById(veranstaltungId);
+        return result != null
+                && result.getVeranstaltungPhase() != null
+                && result.getVeranstaltungPhase() == PHASE_LAUFEND;
+    }
+
     @Override
     public VeranstaltungDO findByLigaIDAndSportjahr(long ligaId, long sportjahr) {
         Preconditions.checkArgument(ligaId >= 0, PRECONDITION_MSG_VERANSTALTUNG_ID);

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImpl.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImpl.java
@@ -98,19 +98,34 @@ public class VeranstaltungComponentImpl implements VeranstaltungComponent {
         return VeranstaltungMapper.toVeranstaltungDOext(result);
     }
 
-    /** Numerischer Phasenwert fuer 'Laufend' (zentral aus {@link VeranstaltungPhase}). */
-    private static final int PHASE_LAUFEND = new VeranstaltungPhase().getPhaseAsInt(VeranstaltungPhase.Phase.LAUFEND);
+    /** Zentrale Phasen-Hilfslogik (String &lt;-&gt; numerischer Phasenwert). */
+    private static final VeranstaltungPhase VERANSTALTUNG_PHASE = new VeranstaltungPhase();
+    /** Numerischer Phasenwert fuer 'Laufend'. */
+    private static final int PHASE_LAUFEND = VERANSTALTUNG_PHASE.getPhaseAsInt(VeranstaltungPhase.Phase.LAUFEND);
+
+    /**
+     * Einzige Stelle, an der ueber 'Laufend' entschieden wird: Vergleich des
+     * numerischen Phasenwerts (robuster als das String-Label). Null-safe.
+     */
+    private static boolean isPhaseLaufend(final Integer phase) {
+        return phase != null && phase == PHASE_LAUFEND;
+    }
 
     @Override
     public boolean isVeranstaltungLaufend(final long veranstaltungId) {
         Preconditions.checkArgument(veranstaltungId >= 0, PRECONDITION_MSG_VERANSTALTUNG_ID);
 
-        // Direkt auf der BE den numerischen Phasenwert vergleichen (robuster als das
-        // String-Label). Null-safe: existiert die Veranstaltung nicht, ist sie nicht 'Laufend'.
+        // Null-safe: existiert die Veranstaltung nicht, ist sie nicht 'Laufend'.
         final VeranstaltungBEext result = veranstaltungDAOext.findById(veranstaltungId);
-        return result != null
-                && result.getVeranstaltungPhase() != null
-                && result.getVeranstaltungPhase() == PHASE_LAUFEND;
+        return result != null && isPhaseLaufend(result.getVeranstaltungPhase());
+    }
+
+    @Override
+    public boolean isVeranstaltungLaufend(final VeranstaltungDO veranstaltung) {
+        // Variante fuer bereits geladene Veranstaltungen (vermeidet ein erneutes findById).
+        // Das DO traegt nur das Label -> zentral in den numerischen Phasenwert wandeln.
+        return veranstaltung != null
+                && isPhaseLaufend(VERANSTALTUNG_PHASE.getPhaseFromStringToInt(veranstaltung.getVeranstaltungPhase()));
     }
 
     @Override

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImplTest.java
@@ -985,4 +985,31 @@ final VeranstaltungBEext expectedBEext = new VeranstaltungBEext();
 */
 
 
+    @Test
+    public void isVeranstaltungLaufend_laufend_true() {
+        final VeranstaltungBEext be = new VeranstaltungBEext();
+        be.setVeranstaltungId(VERANSTALTUNG_ID);
+        be.setVeranstaltungPhase(VERANSTALTUNG_PHASE_LAUFEND); // 2 = Laufend
+        when(veranstaltungDAOext.findById(VERANSTALTUNG_ID)).thenReturn(be);
+
+        assertThat(underTest.isVeranstaltungLaufend(VERANSTALTUNG_ID)).isTrue();
+    }
+
+    @Test
+    public void isVeranstaltungLaufend_geplant_false() {
+        final VeranstaltungBEext be = new VeranstaltungBEext();
+        be.setVeranstaltungId(VERANSTALTUNG_ID);
+        be.setVeranstaltungPhase(VERANSTALTUNG_PHASE); // 1 = Geplant
+        when(veranstaltungDAOext.findById(VERANSTALTUNG_ID)).thenReturn(be);
+
+        assertThat(underTest.isVeranstaltungLaufend(VERANSTALTUNG_ID)).isFalse();
+    }
+
+    @Test
+    public void isVeranstaltungLaufend_notFound_false() {
+        when(veranstaltungDAOext.findById(anyLong())).thenReturn(null);
+
+        assertThat(underTest.isVeranstaltungLaufend(VERANSTALTUNG_ID)).isFalse();
+    }
+
 }

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImplTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/veranstaltung/impl/business/VeranstaltungComponentImplTest.java
@@ -1012,4 +1012,25 @@ final VeranstaltungBEext expectedBEext = new VeranstaltungBEext();
         assertThat(underTest.isVeranstaltungLaufend(VERANSTALTUNG_ID)).isFalse();
     }
 
+    @Test
+    public void isVeranstaltungLaufend_byDO_laufend_true() {
+        final VeranstaltungDO veranstaltungDO = new VeranstaltungDO();
+        veranstaltungDO.setVeranstaltungPhase(VERANSTALTUNG_PHASE_LAUFEND_NAME); // "Laufend"
+
+        assertThat(underTest.isVeranstaltungLaufend(veranstaltungDO)).isTrue();
+    }
+
+    @Test
+    public void isVeranstaltungLaufend_byDO_geplant_false() {
+        final VeranstaltungDO veranstaltungDO = new VeranstaltungDO();
+        veranstaltungDO.setVeranstaltungPhase(VERANSTALTUNG_PHASE_GEPLANT); // "Geplant"
+
+        assertThat(underTest.isVeranstaltungLaufend(veranstaltungDO)).isFalse();
+    }
+
+    @Test
+    public void isVeranstaltungLaufend_byDO_null_false() {
+        assertThat(underTest.isVeranstaltungLaufend((VeranstaltungDO) null)).isFalse();
+    }
+
 }


### PR DESCRIPTION
…hafts-Aenderungen sperren

Ergaenzung zu swt2#2157 (Frontend-Sperre). Bei Phase 'Laufend' werfen create, assignMannschaftToVeranstaltung, unassignMannschaftFromVeranstaltung sowie MannschaftSortierung.update jetzt eine BusinessException (ENTITY_CONFLICT_ERROR), sodass die Regel nicht per direktem API-Call umgangen werden kann. Inkl. Backend-Tests (laufend -> abgelehnt, geplant -> erlaubt). Ticket swt2#2229.