### PR TITLE
fix(security): allow unauthenticated access to kampfrichter-session m…

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/springconfiguration/security/WebSecurityConfiguration.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/springconfiguration/security/WebSecurityConfiguration.java
@@ -68,7 +68,10 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v2/api-docs")
                 .antMatchers("/webjars/**")
                 .antMatchers(HttpMethod.POST, "/v1/signin")
-                .antMatchers(HttpMethod.POST, "/v1/user/signin");
+                .antMatchers(HttpMethod.POST, "/v1/user/signin")
+                // Kampfrichter-Session read endpoints: protected by QR token, no JWT needed
+                .antMatchers(HttpMethod.GET, "/v1/kampfrichter-session/matches")
+                .antMatchers(HttpMethod.PUT, "/v1/kampfrichter-session/strafpunkte");
     }
 
 


### PR DESCRIPTION
Security: Kampfrichter-Session-Endpoints öffentlich zugänglich
 Die Endpoints GET /v1/kampfrichter-session/matches und PUT /v1/kampfrichter-session/strafpunkte wurden in der Spring Security Konfiguration als öffentlich zugänglich eingetragen (web.ignoring()).