### PR TITLE
#2217 Anzeigen Permissionprobleme beheben

### DIFF
--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -44,7 +44,7 @@ public class AnzeigenService implements ServiceFacade {
      * @return list of {@link AnzeigenDTO} as JSON
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm={UserPermission.CAN_READ_SYSTEMDATEN})
+    @RequiresOnePermissions(perm={UserPermission.CAN_READ_STAMMDATEN})
     public List<AnzeigenDTO> findAll() {
         final List<AnzeigenDO> anzeigenDOList = anzeigenComponent.findAll();
         LOG.debug("Received Anzeigen request");
@@ -74,7 +74,7 @@ public class AnzeigenService implements ServiceFacade {
      * @return list of {@link AnzeigenDTO} as JSON
      */
     @GetMapping(value = "byWettkampfId/{wettkampfId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm={UserPermission.CAN_READ_SYSTEMDATEN})
+    @RequiresOnePermissions(perm={UserPermission.CAN_READ_STAMMDATEN})
     public List<AnzeigenDTO> findByWettkampfId(@PathVariable("wettkampfId") final long wettkampfId) {
         Preconditions.checkArgument(wettkampfId > 0, "ID must not be negative.");
 
@@ -95,7 +95,7 @@ public class AnzeigenService implements ServiceFacade {
     @PostMapping(
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm = {UserPermission.CAN_CREATE_SYSTEMDATEN})
+    @RequiresOnePermissions(perm = {UserPermission.CAN_CREATE_STAMMDATEN, UserPermission.CAN_CREATE_STAMMDATEN_LIGALEITER})
     public long create(@RequestBody final Long wettkampfId, final Principal principal) {
 
         Preconditions.checkNotNull(wettkampfId, "Wettkampf ID must not be null.");
@@ -122,7 +122,7 @@ public class AnzeigenService implements ServiceFacade {
     @PutMapping(
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_SYSTEMDATEN})
+    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_STAMMDATEN, UserPermission.CAN_MODIFY_STAMMDATEN_LIGALEITER})
     public AnzeigenDTO update(@RequestBody final AnzeigenDTO anzeigenDTO, final Principal principal) {
 
         LOG.debug("Received 'update' request with id '{}'", anzeigenDTO.getId());
@@ -156,7 +156,7 @@ public class AnzeigenService implements ServiceFacade {
      *
      */
     @DeleteMapping(value = "{id}")
-    @RequiresOnePermissions(perm = {UserPermission.CAN_MODIFY_SYSTEMDATEN})
+    @RequiresOnePermissions(perm = {UserPermission.CAN_DELETE_STAMMDATEN, UserPermission.CAN_MODIFY_STAMMDATEN_LIGALEITER})
     public void delete(@PathVariable final Long id, final Principal principal) {
         Preconditions.checkNotNull(id, "ID must not be null.");
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -61,7 +61,7 @@ public class AnzeigenService implements ServiceFacade {
      * @return list of {@link AnzeigenDTO} as JSON
      */
     @GetMapping(value = "{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @RequiresOnePermissions(perm={UserPermission.CAN_READ_SYSTEMDATEN})
+    @RequiresOnePermissions(perm={UserPermission.CAN_READ_STAMMDATEN})
     public AnzeigenDTO findById(@PathVariable("id") final long id) {
         Preconditions.checkArgument(id > 0, "ID must not be negative.");
 

--- a/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
+++ b/bogenliga/bogenliga-application/src/main/java/de/bogenliga/application/services/v1/wettkampf/service/AnzeigenService.java
@@ -20,7 +20,10 @@ import de.bogenliga.application.common.service.ServiceFacade;
 import de.bogenliga.application.common.validation.Preconditions;
 import de.bogenliga.application.springconfiguration.security.types.UserPermission;
 
-
+/* Diese Api sollte von Ausrichtern, Ligaleitern und Admins verwendet werden können,
+   kann (Stand SoSe 2026), aber leider nur von Ligaleitern und Admins verwendet werden.
+   Die entsprechenden Permissions für die Ausrichter müssen in Zukunft erstellt,
+   und hier hinzugefügt werden*/
 
 @RestController
 @RequestMapping("v1/anzeigen")


### PR DESCRIPTION
Die Anzeigen können nun auch von Ligaleitern aufgerufen werden. 

Für Ausrichter fehlt weiterhin der Zugriff, da die benötigten permissions noch nicht existieren.

Die Ausrichter-Permissions werden in Absprache mit Gero an das nächste Semester übergeben