### PR TITLE
#2238: Satzeingabe brach mit 'inkonsistente Schuetzen' ab - Gemeldet-…

### DIFF
--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/Satzeingabe.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/Satzeingabe.java
@@ -342,12 +342,12 @@ public class Satzeingabe extends State {
     private void validateShooterRegistration(StateContext context, long shooterId) {
         try {
             long currentMatchId = context.getCurrentMatchId();
-            long currentMatchNr = context.getMatchComponent().findById(currentMatchId).getNr();
-            
+
             MannschaftsmitgliedDO member = context.getMannschaftsmitgliedComponent()
                 .findByMemberAndTeamId(context.getTeamId(), shooterId);
-            
-            if (member.getDsbMitgliedEingesetzt() < currentMatchNr) {
+
+            if (member.getDsbMitgliedEingesetzt() == null
+                    || member.getDsbMitgliedEingesetzt() != Math.toIntExact(currentMatchId)) {
                 throw new BusinessException(ErrorCode.INVALID_ARGUMENT_ERROR,
                     "Shooter " + shooterId + " was not registered in Schützenmeldung for this match");
             }
@@ -363,15 +363,16 @@ public class Satzeingabe extends State {
     
     /**
      * Gets shooters registered for the current match.
+     * Gemeldet-Marker ist die eindeutige Match-ID, nicht die Match-Nr
+     * (Kollision mit dem Kader-Flag eingesetzt=1, siehe Schuetzenmeldung#markShootersAsDeployed).
      */
     private List<Long> getRegisteredShootersForCurrentMatch(StateContext context) {
         try {
             long currentMatchId = context.getCurrentMatchId();
-            long currentMatchNr = context.getMatchComponent().findById(currentMatchId).getNr();
-            
+
             return context.getMannschaftsmitgliedComponent().findByTeamId(context.getTeamId()).stream()
                 .filter(mm -> mm.getDsbMitgliedEingesetzt() != null &&
-                             mm.getDsbMitgliedEingesetzt().equals(Math.toIntExact(currentMatchNr)))
+                             mm.getDsbMitgliedEingesetzt().equals(Math.toIntExact(currentMatchId)))
                 .map(MannschaftsmitgliedDO::getDsbMitgliedId)
                 .distinct() // Remove duplicates
                 .collect(Collectors.toList());

--- a/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/Schuetzenmeldung.java
+++ b/bogenliga/bogenliga-business-logic/src/main/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/Schuetzenmeldung.java
@@ -198,19 +198,23 @@ public class Schuetzenmeldung extends State {
     }
     
     /**
-     * Marks shooters as deployed for current match using match number.
+     * Marks shooters as deployed for current match using the unique match id.
+     *
+     * <p>Die Match-Nr (1..7) darf hier nicht verwendet werden: sie kollidiert mit dem
+     * Kader-Flag {@code eingesetzt = 1} ("in der Schuetzenmeldung waehlbar"). Bei
+     * Mannschaften mit mehr als 3 Kadermitgliedern galten dadurch in Match Nr. 1
+     * alle Mitglieder als "gemeldet" und die Satzeingabe brach mit
+     * "inkonsistente Schuetzen" ab.</p>
      */
     private void markShootersAsDeployed(StateContext context, List<Long> shooterIds) {
         try {
-            // Get current match number from session
             long currentMatchId = context.getCurrentMatchId();
-            long currentMatchNr = context.getMatchComponent().findById(currentMatchId).getNr();
-            
+
             for (Long shooterId : shooterIds) {
                 try {
                     MannschaftsmitgliedDO member = context.getMannschaftsmitgliedComponent()
                         .findByMemberAndTeamId(context.getTeamId(), shooterId);
-                    member.setDsbMitgliedEingesetzt(Math.toIntExact(currentMatchNr));
+                    member.setDsbMitgliedEingesetzt(Math.toIntExact(currentMatchId));
                     context.getMannschaftsmitgliedComponent().update(member, 0L);
 
                 } catch (Exception e) {
@@ -231,11 +235,10 @@ public class Schuetzenmeldung extends State {
     private List<MannschaftsmitgliedDO> getDeployedMembersForCurrentMatch(StateContext context) {
         try {
             long currentMatchId = context.getCurrentMatchId();
-            long currentMatchNr = context.getMatchComponent().findById(currentMatchId).getNr();
-            
+
             return context.getMannschaftsmitgliedComponent().findByTeamId(context.getTeamId()).stream()
                 .filter(mm -> mm.getDsbMitgliedEingesetzt() != null &&
-                             mm.getDsbMitgliedEingesetzt().equals(Math.toIntExact(currentMatchNr)))
+                             mm.getDsbMitgliedEingesetzt().equals(Math.toIntExact(currentMatchId)))
                 .collect(Collectors.toList());
         } catch (Exception e) {
             LOGGER.error("Error getting deployed members for current match: {}", e.getMessage());

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/SatzeingabeTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/SatzeingabeTest.java
@@ -64,10 +64,11 @@ public class SatzeingabeTest {
         testMatch.setSatzpunkte(2L);
         testMatch.setMatchpunkte(0L);
         
+        // gemeldet = eingesetzt traegt die eindeutige Match-ID (300), nicht die Match-Nr
         testTeamMembers = Arrays.asList(
-            createTeamMember(1L, 101L, 1),
-            createTeamMember(2L, 102L, 1),
-            createTeamMember(3L, 103L, 1)
+            createTeamMember(1L, 101L, 300),
+            createTeamMember(2L, 102L, 300),
+            createTeamMember(3L, 103L, 300)
         );
         
         testMembers = Arrays.asList(
@@ -373,6 +374,22 @@ public class SatzeingabeTest {
     public void getRegisteredShootersForCurrentMatch_validMatch_returnsShooters() {
         Map<String, Object> result = state.prepareResponseData(mockContext);
         assertThat(result).isNotNull();
+
+        @SuppressWarnings("unchecked")
+        List<SchuetzeStammdatenDO> stammdaten = (List<SchuetzeStammdatenDO>) result.get("schuetzeStammDaten");
+        assertThat(stammdaten).hasSize(3);
+    }
+
+    @Test
+    public void prepareResponseData_kaderFlagMemberNotCountedAsRegistered() {
+        // Regression zum Ticket "inkonsistente Schuetzen": ein 4. Kadermitglied mit
+        // blossem Waehlbar-Flag (eingesetzt=1) kollidierte frueher mit Match Nr. 1
+        // und liess die Satzeingabe mit >3 Schuetzen abbrechen
+        List<MannschaftsmitgliedDO> membersWithExtra = new ArrayList<>(testTeamMembers);
+        membersWithExtra.add(createTeamMember(4L, 104L, 1));
+        when(mockMannschaftsmitgliedComponent.findByTeamId(100L)).thenReturn(membersWithExtra);
+
+        Map<String, Object> result = state.prepareResponseData(mockContext);
 
         @SuppressWarnings("unchecked")
         List<SchuetzeStammdatenDO> stammdaten = (List<SchuetzeStammdatenDO>) result.get("schuetzeStammDaten");

--- a/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/SchuetzenmeldungTest.java
+++ b/bogenliga/bogenliga-business-logic/src/test/java/de/bogenliga/application/business/schusszettel/impl/business/domain/states/SchuetzenmeldungTest.java
@@ -122,12 +122,13 @@ public class SchuetzenmeldungTest {
 
     @Test
     public void isDatabaseReadyForTransition_threeShootersDeployed_returnsTrue() {
-        when(mockMmComponent.findByTeamId(100L)).thenReturn(
-            testTeamMembers.stream()
-                .filter(tm -> tm.getDsbMitgliedEingesetzt().equals(1))
-                .toList()
-        );
-        
+        // gemeldet = eingesetzt traegt die Match-ID (200), nicht die Match-Nr
+        when(mockMmComponent.findByTeamId(100L)).thenReturn(Arrays.asList(
+            createTeamMember(1L, 101L, 200),
+            createTeamMember(2L, 102L, 200),
+            createTeamMember(3L, 103L, 200)
+        ));
+
         boolean result = state.isDatabaseReadyForTransition(mockContext, State.STATUS_SATZEINGABE);
         assertThat(result).isTrue();
     }
@@ -250,9 +251,14 @@ public class SchuetzenmeldungTest {
         
         boolean result = state.handlePostOperation(mockContext, "submitSchuetzen", shooterIds);
         assertThat(result).isTrue();
-        
+
         verify(mockContext).updateSessionStatus(State.STATUS_SATZEINGABE);
         verify(mockMmComponent, times(3)).update(any(MannschaftsmitgliedDO.class), eq(0L));
+
+        // eingesetzt muss die eindeutige Match-ID tragen, nicht die Match-Nr
+        assertThat(testTeamMembers.get(0).getDsbMitgliedEingesetzt()).isEqualTo(200);
+        assertThat(testTeamMembers.get(1).getDsbMitgliedEingesetzt()).isEqualTo(200);
+        assertThat(testTeamMembers.get(2).getDsbMitgliedEingesetzt()).isEqualTo(200);
     }
 
     @Test
@@ -300,8 +306,15 @@ public class SchuetzenmeldungTest {
 
     @Test
     public void getDeployedMembersForCurrentMatch_validMatch_returnsFilteredMembers() {
-        when(mockMmComponent.findByTeamId(100L)).thenReturn(testTeamMembers);
-        
+        // Regression zum Ticket "inkonsistente Schuetzen": Kadermitglieder mit
+        // blossem Waehlbar-Flag (eingesetzt=1) duerfen nicht als gemeldet zaehlen
+        when(mockMmComponent.findByTeamId(100L)).thenReturn(Arrays.asList(
+            createTeamMember(1L, 101L, 200),
+            createTeamMember(2L, 102L, 200),
+            createTeamMember(3L, 103L, 200),
+            createTeamMember(4L, 104L, 1)
+        ));
+
         boolean result = state.isDatabaseReadyForTransition(mockContext, State.STATUS_SATZEINGABE);
         assertThat(result).isTrue();
     }


### PR DESCRIPTION
…Marker auf Match-ID umgestellt

Das Feld mannschaftsmitglied_dsb_mitglied_eingesetzt wurde doppelt genutzt: als Kader-Flag (>=1 = in der Schützenmeldung wählbar) und als Gemeldet-Marker (== Match-Nr). Bei Match Nr. 1 kollidierte der Marker mit dem Flag: bei Mannschaften mit mehr als 3 Kadermitgliedern galten alle als gemeldet, das Backend lieferte >3 schützeStammDaten und das Frontend brach die Passe-Eingabe ab.

Fix: eingesetzt traegt jetzt die eindeutige Match-ID statt der Match-Nr (Schützenmeldung.markShootersAsDeployed/getDeployedMembersForCurrentMatch, Satzeingabe.getRegisteredShootersForCurrentMatch/validateShooterRegistration). Der Pool-Filter eingesetzt >= 1 bleibt gueltig, da Match-IDs >= 1 sind. Tests angepasst plus Regressionstests fuer das Ticket-Szenario.